### PR TITLE
fix: add @prisma/client to NonBundleablePackages

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -54,4 +54,5 @@ export const NonBundleablePackages = [
   "pg", // CJS module incompatible with Rollup/Rolldown bundling
   "sequelize", // Dynamic requires that cannot be statically analyzed
   "@discordjs/ws", // Optional dependency breaks build
+  "@prisma/client", // CJS module using __dirname incompatible with Rollup/Rolldown bundling
 ];


### PR DESCRIPTION
## Changes

Adds `@prisma/client` to `NonBundleablePackages` - which in turn results in ` @prisma/client` being added to `nitro`'s `traceDeps` config (https://github.com/nitrojs/nitro/blob/ef01b092b5fa09d28acb5bd0668ae80505f7c6b4/src/build/plugins.ts#L60).

## Background

`@prisma/client` is a CJS module that uses `__dirname`. Nitro started bundling dependencies by default in [v3.0.1-alpha.2
](https://github.com/nitrojs/nitro/releases/tag/v3.0.1-alpha.2), instead of copying them. The bundling of `@prisma/client` results in a `ReferenceError: __dirname is not defined in ES module scope` runtime error. By adding it to `NonBundleablePackages` (and therefore nitro's `traceDeps`) it will be loaded as a CJS module with support for `__dirname`. 

This fix should be unnecessary in the future as Prisma 7 stops using `@prisma/client` node_module tricks and improves ES module support, but it is needed for users who still rely on the previous Prisma 6.19.
