### PR TITLE
fix(plugin): use `writeBundle` hook to avoid vite `emptyOutDir` race

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -121,7 +121,7 @@ export function externals(opts: ExternalsPluginOptions): Plugin {
         };
       },
     },
-    buildEnd: {
+    writeBundle: {
       order: "post",
       async handler() {
         if (opts.trace === false || tracedPaths.size === 0) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves https://github.com/unjs/nf3/issues/24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized build process execution timing while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->