### PR TITLE
fix(plugin): use `traceInclude`

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -124,6 +124,13 @@ export function externals(opts: ExternalsPluginOptions): Plugin {
     writeBundle: {
       order: "post",
       async handler() {
+        for (const entry of opts.traceInclude || []) {
+          tracedPaths.add(
+            isAbsolute(entry)
+              ? entry
+              : tryResolve(entry, undefined) ?? resolve(rootDir, entry)
+          );
+        }
         if (opts.trace === false || tracedPaths.size === 0) {
           return;
         }


### PR DESCRIPTION
```ts
import { defineConfig } from "vite";
import { externals } from "nf3/plugin";

export default defineConfig({
  build: {
    rollupOptions: {
      input: ["src/server.js"],
      plugins: [
        externals({
          traceInclude: ["node_modules/import-in-the-middle/hook.mjs"],
        }),
      ],
    },
  },
});
```

~~Note: The example config in the readme contains: `traceInclude: ["some-lib"]`. Maybe this should be changed to `traceInclude: ["some-lib/index.js"]`?~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundling now respects additional configured trace-includes, ensuring extra paths are considered during tracing.
  * This improves dependency resolution and reduces missed assets during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->