### PR TITLE
feat(trace): add FullTracePackages db

### DIFF
--- a/scripts/trace.ts
+++ b/scripts/trace.ts
@@ -16,7 +16,7 @@ import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:f
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
-import { NodeNativePackages } from "../src/db.ts";
+import { NodeNativePackages, FullTracePackages } from "../src/db.ts";
 import { traceNodeModules } from "../src/trace.ts";
 
 // ANSI colors
@@ -27,8 +27,6 @@ const c = {
   dim: (s: string) => `\x1b[2m${s}\x1b[0m`,
   bold: (s: string) => `\x1b[1m${s}\x1b[0m`,
 };
-
-const fullTrace: string[] = ["lmdb"];
 
 const { values: args } = parseArgs({
   options: {
@@ -109,7 +107,7 @@ async function tracePkg(pkg: string): Promise<TraceResult> {
       rootDir: pkgDir,
       outDir: "dist",
       writePackageJson: true,
-      fullTraceInclude: fullTrace,
+      fullTraceInclude: [...FullTracePackages],
       hooks: {
         tracedPackages(packages) {
           tracedPkgNames = Object.keys(packages);

--- a/src/db.ts
+++ b/src/db.ts
@@ -113,10 +113,18 @@ export const NodeNativePackages: readonly string[] = Object.freeze([
 ]);
 
 /**
+ * Packages that should be fully traced (including all source files)
+ */
+export const FullTracePackages = ["usb", "sodium-native", "aws-crt", "youch"] as const;
+
+/**
  * Packages that must be externalized (traced as dependencies) rather than bundled,
  * due to bundler compatibility issues with their module format or dynamic imports.
  */
 export const NonBundleablePackages = [
+  // Has local assets
+  "youch",
+
   // Database drivers / ORMs
   "pg-native", // Dynamic native binary loading companion to pg
   "typeorm", // Dynamic entity/driver loading via require()

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -100,18 +100,21 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
       const fullTraceEntry = resolveFullTraceEntry(opts.fullTraceInclude, pkgName);
       if (fullTraceEntry) {
-        if (!fsp.glob) {
-          throw new Error("`fullTraceInclude` requires Node.js >= 22.0.0 (fs.promises.glob)");
-        }
-        const globPattern = fullTraceEntry.glob || "{**,.**}/{.*,*}";
-        for await (const file of fsp.glob(globPattern, {
-          cwd: tracedFile.pkgPath,
-          exclude: (name) => name === "node_modules",
-        })) {
-          const fullPath = join(tracedFile.pkgPath, file);
-          if (await isFile(fullPath)) {
-            tracedPackageVersion.files.push(fullPath);
+        if (fullTraceEntry.glob) {
+          if (!fsp.glob) {
+            throw new Error("`fullTraceInclude` glob requires Node.js >= 22.0.0 (fs.promises.glob)");
           }
+          for await (const file of fsp.glob(fullTraceEntry.glob, {
+            cwd: tracedFile.pkgPath,
+            exclude: (name) => name === "node_modules",
+          })) {
+            const fullPath = join(tracedFile.pkgPath, file);
+            if (await isFile(fullPath)) {
+              tracedPackageVersion.files.push(fullPath);
+            }
+          }
+        } else {
+          tracedPackageVersion.files.push(...await listPkgFiles(tracedFile.pkgPath));
         }
       }
     }
@@ -148,20 +151,7 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
         }
         const depVersion = depPkgJSON.version || "0.0.0";
         // Full-trace copy all files from this package
-        const files: string[] = [];
-        for (const entry of await fsp.readdir(depPath, {
-          recursive: true,
-          withFileTypes: true,
-        })) {
-          if (!entry.isFile()) {
-            continue;
-          }
-          const parentPath = entry.parentPath;
-          if (parentPath.slice(depPath.length).includes("node_modules")) {
-            continue;
-          }
-          files.push(join(parentPath, entry.name));
-        }
+        const files = await listPkgFiles(depPath);
         tracedPackages[depName] = {
           name: depName,
           versions: {
@@ -381,6 +371,23 @@ function resolveFullTraceEntry(
     }
   }
   return undefined;
+}
+
+async function listPkgFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await fsp.readdir(dir, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (entry.parentPath.slice(dir.length).includes("node_modules")) {
+      continue;
+    }
+    files.push(join(entry.parentPath, entry.name));
+  }
+  return files;
 }
 
 async function isFile(file: string) {

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -102,7 +102,9 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
       if (fullTraceEntry) {
         if (fullTraceEntry.glob) {
           if (!fsp.glob) {
-            throw new Error("`fullTraceInclude` glob requires Node.js >= 22.0.0 (fs.promises.glob)");
+            throw new Error(
+              "`fullTraceInclude` glob requires Node.js >= 22.0.0 (fs.promises.glob)",
+            );
           }
           for await (const file of fsp.glob(fullTraceEntry.glob, {
             cwd: tracedFile.pkgPath,
@@ -114,7 +116,7 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
             }
           }
         } else {
-          tracedPackageVersion.files.push(...await listPkgFiles(tracedFile.pkgPath));
+          tracedPackageVersion.files.push(...(await listPkgFiles(tracedFile.pkgPath)));
         }
       }
     }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -386,7 +386,7 @@ async function listPkgFiles(dir: string): Promise<string[]> {
     if (relPath.split("/").includes("node_modules")) {
       continue;
     }
-    if (entry.isFile() || (entry.isSymbolicLink() && await isFile(fullPath))) {
+    if (entry.isFile() || (entry.isSymbolicLink() && (await isFile(fullPath)))) {
       files.push(fullPath);
     }
   }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -381,13 +381,14 @@ async function listPkgFiles(dir: string): Promise<string[]> {
     recursive: true,
     withFileTypes: true,
   })) {
-    if (!entry.isFile()) {
+    const fullPath = join(entry.parentPath, entry.name);
+    const relPath = fullPath.slice(dir.length);
+    if (relPath.split("/").includes("node_modules")) {
       continue;
     }
-    if (entry.parentPath.slice(dir.length).includes("node_modules")) {
-      continue;
+    if (entry.isFile() || (entry.isSymbolicLink() && await isFile(fullPath))) {
+      files.push(fullPath);
     }
-    files.push(join(entry.parentPath, entry.name));
   }
   return files;
 }


### PR DESCRIPTION
- add new `FullTracePackages` export to DB for packages that their files cannot by analyzed by nft
- Add `youch` to `NonBundleablePackages` (has local assets)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced package tracing list to better support several native modules and utilities, improving bundling behavior.
* **Bug Fixes**
  * Improved file discovery for traced packages and optional dependencies to reduce missing-file/bundle issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->