### PR TITLE
fix(trace): skip missing realpath trace entries

### DIFF
--- a/src/trace.ts
+++ b/src/trace.ts
@@ -31,8 +31,16 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
   await opts?.hooks?.traceResult?.(traceResult);
 
   // Resolve traced files
-  const _resolveTracedPath = (p: string) =>
-    fsp.realpath(resolve(opts.nft?.base || "/", p)).then((p) => normalize(p));
+  const _resolveTracedPath = async (p: string) => {
+    try {
+      return normalize(await fsp.realpath(resolve(opts.nft?.base || "/", p)));
+    } catch (error: any) {
+      if (error?.code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+  };
 
   const tracedFiles: Record<string, TracedFile> = Object.fromEntries(
     (await Promise.all(
@@ -41,7 +49,7 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
           return;
         }
         const path = await _resolveTracedPath(_path);
-        if (!path.includes("node_modules")) {
+        if (!path?.includes("node_modules")) {
           return;
         }
         if (!(await isFile(path))) {
@@ -52,7 +60,9 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
           return;
         }
         const pkgPath = join(baseDir, pkgName);
-        const parents = await Promise.all([...reasons.parents].map((p) => _resolveTracedPath(p)));
+        const parents = (
+          await Promise.all([...reasons.parents].map((p) => _resolveTracedPath(p)))
+        ).filter((p): p is string => p !== undefined);
         const tracedFile = <TracedFile>{
           path,
           parents,

--- a/test/trace-mock.test.ts
+++ b/test/trace-mock.test.ts
@@ -10,8 +10,10 @@ import {
 } from "./_mock-utils.ts";
 
 const { nodeFileTrace } = await import("@vercel/nft");
+const { realpath } = await import("node:fs/promises");
 const { traceNodeModules } = await import("../src/trace.ts");
 const mockNodeFileTrace = vi.mocked(nodeFileTrace);
+const mockRealpath = vi.mocked(realpath);
 
 // --- Test matrix types ---
 
@@ -317,6 +319,7 @@ describe("traceNodeModules (mocked nft)", () => {
   beforeEach(() => {
     resetMockFs();
     mockNodeFileTrace.mockReset();
+    mockRealpath.mockImplementation((p: any) => Promise.resolve(p));
   });
 
   // --- Matrix-driven tests ---
@@ -383,6 +386,42 @@ describe("traceNodeModules (mocked nft)", () => {
   }
 
   // --- Tests that need custom logic beyond the matrix ---
+
+  it("skips missing traced files and parent paths", async () => {
+    seedPackages(ROOT, {
+      "pkg-a": { version: "1.0.0", files: { "index.js": "a" } },
+    });
+
+    const pkgFile = nm("pkg-a", "index.js");
+    const missingFile = nm("missing-native", "index.js");
+    const missingParent = nm("missing-parent", "index.js");
+
+    mockRealpath.mockImplementation((p: any) => {
+      if (p === missingFile || p === missingParent) {
+        return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      }
+      return Promise.resolve(p);
+    });
+
+    mockNodeFileTrace.mockResolvedValue(
+      createNftResult({
+        [pkgFile]: { parents: [missingParent] },
+        [missingFile]: { parents: [pkgFile] },
+      }),
+    );
+
+    const tracedFiles = vi.fn();
+    await traceNodeModules([join(ROOT, "entry.js")], {
+      rootDir: ROOT,
+      outDir: OUT,
+      hooks: { tracedFiles },
+    });
+
+    expect(writtenFiles.get(join(OUT, "node_modules/pkg-a/index.js"))).toBe("a");
+    expect(tracedFiles).toHaveBeenCalledWith({
+      [pkgFile]: expect.objectContaining({ parents: [] }),
+    });
+  });
 
   it("hoists version with most dependants to top level", async () => {
     seedPackages(ROOT, {


### PR DESCRIPTION
**What changed**

`traceNodeModules()` now tolerates `ENOENT` while resolving traced paths with `realpath()`.

If the traced file itself is missing, nf3 skips that trace entry. If a parent path is missing, nf3 drops that parent link before computing package relationships. Other `realpath()` errors still throw.

**Why**

`@vercel/nft` can report paths for dynamically required platform optional dependencies. With pnpm, non-current-platform optional packages can exist as dangling symlinks when the target package was not installed.

That made nf3 crash before it could skip the missing file or run the optional dependency copy pass.

Minimal reproduction: https://github.com/remorses/nf3-realpath-optional-repro
Related issue: #42

**Validation**

```sh
pnpm vitest run test/trace-mock.test.ts
pnpm test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in trace resolution to gracefully handle missing files instead of failing.
  * Parent path resolution is now more robust with parallel processing and safe filtering.

* **Tests**
  * Added test coverage for edge cases involving missing traced files and parent paths.

cc @pi0 

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/nf3/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->