### PR TITLE
fix: avoid crash on non-regular files (sockets, FIFOs) during trace

### DIFF
--- a/src/trace.ts
+++ b/src/trace.ts
@@ -18,12 +18,16 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
   // Safe readFile that stat-checks before reading to avoid crashing on
   // non-regular files (Unix sockets, FIFOs, device files, etc.).
+  // Returns empty string instead of null for non-regular files because
+  // @vercel/nft's emitDependency throws "File does not exist" on null,
+  // killing the entire trace. Empty string passes the null check and
+  // the analyzer just finds zero deps, which is correct.
   // https://github.com/unjs/nf3/issues/44
   const safeReadFile = async (path: string): Promise<string | null> => {
     try {
       const stat = await fsp.stat(path);
       if (!stat || !stat.isFile()) {
-        return null;
+        return "";
       }
       return (await fsp.readFile(path)).toString();
     } catch {

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -16,11 +16,27 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
   await opts?.hooks?.traceStart?.(input);
 
+  // Safe readFile that stat-checks before reading to avoid crashing on
+  // non-regular files (Unix sockets, FIFOs, device files, etc.).
+  // https://github.com/unjs/nf3/issues/44
+  const safeReadFile = async (path: string): Promise<string | null> => {
+    try {
+      const stat = await fsp.stat(path);
+      if (!stat || !stat.isFile()) {
+        return null;
+      }
+      return (await fsp.readFile(path)).toString();
+    } catch {
+      return null;
+    }
+  };
+
   // Trace used files using nft
   const traceResult = await nodeFileTrace([...input], {
     base: "/",
     exportsOnly: true,
     processCwd: rootDir,
+    readFile: safeReadFile,
     // https://github.com/nitrojs/nitro/pull/1562
     conditions: (opts.conditions || DEFAULT_CONDITIONS).filter(
       (c) => !["require", "import", "default"].includes(c),


### PR DESCRIPTION
Fixes #44

**Problem**

`nodeFileTrace` crashes with `Unknown system error -102` when it encounters Unix domain socket files (or other non-regular files like FIFOs) in traced paths. Common trigger: Playwright/Chromium creates `SingletonSocket` and `SingletonLock` files under `/tmp/` which get discovered during dependency tracing.

Two issues at play:

1. `@vercel/nft`'s `_internalReadFile` calls `fs.readFile()` on non-regular files without checking `stat.isFile()` first, causing the system error
2. Even with a custom `readFile` that returns `null` for non-regular files, `emitDependency` does `if (e === null) throw Error("File " + r + " does not exist.")`, killing the entire trace

**Fix**

Pass a custom `readFile` to `nodeFileTrace` that stat-checks before reading. For non-regular files it returns `""` (empty string) instead of `null`. Empty string passes the null check in `emitDependency`, and the analyzer just finds zero dependencies in it, which is correct for sockets and FIFOs.

The `emitDependency` throw in `@vercel/nft` should ideally be a warning, not a fatal error. That's a deeper fix for `@vercel/nft` itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the module tracing process with safer file handling that checks file types before reading, preventing crashes when encountering non-regular files (e.g., sockets, FIFOs, device files).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/nf3/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->