### PR TITLE
fix: trace pnpm nested dependencies via traceInclude

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -124,30 +124,15 @@ export function externals(opts: ExternalsPluginOptions): Plugin {
     writeBundle: {
       order: "post",
       async handler() {
-        // Resolve `traceInclude` entries. pnpm does not hoist transitive deps
-        // to the top-level node_modules, so a nested package (e.g. a native dep
-        // pulled in indirectly) cannot be resolved from `rootDir`. Fall back to
-        // resolving it from the packages that were externalized during the
-        // build. https://github.com/unjs/nf3/issues/49
-        const traceFromPaths = [...tracedPaths];
-        for (const entry of opts.traceInclude || []) {
-          if (isAbsolute(entry)) {
-            tracedPaths.add(entry);
-            continue;
-          }
-          let resolved = tryResolve(entry, undefined);
-          for (const from of traceFromPaths) {
-            if (resolved) {
-              break;
-            }
-            resolved = tryResolve(entry, from);
-          }
-          tracedPaths.add(resolved ?? resolve(rootDir, entry));
-        }
-        if (opts.trace === false || tracedPaths.size === 0) {
+        if (opts.trace === false || (tracedPaths.size === 0 && !opts.traceInclude?.length)) {
           return;
         }
         const traceOpts = opts.trace === true ? {} : opts.trace;
+        // `traceInclude` packages (e.g. native deps loaded dynamically) are
+        // resolved inside `traceNodeModules` against both `rootDir` and the
+        // traced input locations, so they work with pnpm's non-hoisted layout.
+        // https://github.com/unjs/nf3/issues/49
+        const traceInclude = [...(opts.traceInclude || []), ...(traceOpts?.traceInclude || [])];
         // Pre-resolve fullTraceInclude package names to traced paths
         if (traceOpts?.fullTraceInclude) {
           for (const pkg of traceOpts.fullTraceInclude) {
@@ -163,6 +148,7 @@ export function externals(opts: ExternalsPluginOptions): Plugin {
           conditions: opts.conditions,
           rootDir,
           ...traceOpts,
+          traceInclude,
         });
       },
     },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -124,10 +124,25 @@ export function externals(opts: ExternalsPluginOptions): Plugin {
     writeBundle: {
       order: "post",
       async handler() {
+        // Resolve `traceInclude` entries. pnpm does not hoist transitive deps
+        // to the top-level node_modules, so a nested package (e.g. a native dep
+        // pulled in indirectly) cannot be resolved from `rootDir`. Fall back to
+        // resolving it from the packages that were externalized during the
+        // build. https://github.com/unjs/nf3/issues/49
+        const traceFromPaths = [...tracedPaths];
         for (const entry of opts.traceInclude || []) {
-          tracedPaths.add(
-            isAbsolute(entry) ? entry : (tryResolve(entry, undefined) ?? resolve(rootDir, entry)),
-          );
+          if (isAbsolute(entry)) {
+            tracedPaths.add(entry);
+            continue;
+          }
+          let resolved = tryResolve(entry, undefined);
+          for (const from of traceFromPaths) {
+            if (resolved) {
+              break;
+            }
+            resolved = tryResolve(entry, from);
+          }
+          tracedPaths.add(resolved ?? resolve(rootDir, entry));
         }
         if (opts.trace === false || tracedPaths.size === 0) {
           return;

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -14,39 +14,10 @@ export const DEFAULT_CONDITIONS = ["node", "import", "default"];
 export async function traceNodeModules(input: string[], opts: ExternalsTraceOptions) {
   const rootDir = resolve(opts.rootDir || ".");
 
-  // Force-include packages that may not be statically traceable (e.g. native
-  // deps loaded dynamically). Resolve each name from `rootDir`, falling back to
-  // the locations of the provided inputs. pnpm does not hoist transitive deps to
-  // the top-level node_modules, so they only resolve from the dependent
-  // package's real `.pnpm` location. https://github.com/unjs/nf3/issues/49
-  const allInput = [...input];
-  for (const name of opts.traceInclude || []) {
-    if (isAbsolute(name)) {
-      allInput.push(name);
-      continue;
-    }
-    let resolved = resolveModulePath(name, {
-      try: true,
-      from: rootDir,
-      conditions: opts.conditions,
-    });
-    for (const from of input) {
-      if (resolved) {
-        break;
-      }
-      // Resolve from the real path so resolution walks the real `.pnpm` tree
-      // rather than the symlinked one (where nested deps are not reachable).
-      const realFrom = await fsp.realpath(from).catch(() => from);
-      resolved = resolveModulePath(name, {
-        try: true,
-        from: realFrom,
-        conditions: opts.conditions,
-      });
-    }
-    if (resolved) {
-      allInput.push(resolved);
-    }
-  }
+  // Absolute `traceInclude` entries are traced directly. Bare package names are
+  // resolved later against the traced package roots (see below) to avoid
+  // resolving against the potentially large `input` file list.
+  const allInput = [...input, ...(opts.traceInclude || []).filter((n) => isAbsolute(n))];
 
   await opts?.hooks?.traceStart?.(allInput);
 
@@ -158,6 +129,65 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
     tracedFile.pkgName = pkgName;
     if (pkgJSON.version) {
       tracedFile.pkgVersion = pkgJSON.version;
+    }
+  }
+
+  // Force-trace explicitly requested packages (`traceInclude`) that may not be
+  // statically reachable (e.g. native deps loaded dynamically). Resolve each
+  // name from `rootDir`, falling back to the already-traced package roots. Under
+  // pnpm a nested dep is not hoisted and only resolves from the dependent
+  // package's real `.pnpm` location. https://github.com/unjs/nf3/issues/49
+  const traceIncludeNames = (opts.traceInclude || []).filter((n) => !isAbsolute(n));
+  if (traceIncludeNames.length > 0) {
+    const fromCandidates = [
+      rootDir,
+      ...new Set(
+        Object.values(tracedPackages).flatMap((p) => Object.values(p.versions).map((v) => v.path)),
+      ),
+    ];
+    for (const name of traceIncludeNames) {
+      if (tracedPackages[name]) {
+        continue;
+      }
+      let resolved: string | undefined;
+      for (const from of fromCandidates) {
+        // Resolve the bare name (then derive the package root below). Resolving
+        // `<name>/package.json` directly is unreliable since a package's
+        // `exports` map usually does not expose it.
+        resolved =
+          resolveModulePath(name, { try: true, from, conditions: opts.conditions }) ||
+          resolveModulePath(name + "/package.json", { try: true, from });
+        if (resolved) {
+          break;
+        }
+      }
+      if (!resolved) {
+        continue;
+      }
+      const { dir, name: resolvedName } = parseNodeModulePath(resolved);
+      if (!dir || !resolvedName) {
+        continue;
+      }
+      const depPath = join(dir, resolvedName);
+      const depPkgJSON = await readJSON(join(depPath, "package.json")).catch(() => null);
+      if (!depPkgJSON) {
+        continue;
+      }
+      const depVersion = depPkgJSON.version || "0.0.0";
+      // Full-trace copy all files (native deps load binaries dynamically, so an
+      // nft trace would miss them). Added before the optionalDependencies pass
+      // below so platform-specific bindings are picked up too.
+      const files = await listPkgFiles(depPath);
+      tracedPackages[name] = {
+        name,
+        versions: {
+          [depVersion]: {
+            path: depPath,
+            files,
+            pkgJSON: depPkgJSON,
+          },
+        },
+      };
     }
   }
 

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -134,16 +134,16 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
   // Force-trace explicitly requested packages (`traceInclude`) that may not be
   // statically reachable (e.g. native deps loaded dynamically). Each name is
-  // resolved from `rootDir` and from the roots of any traced package that
-  // declares it as a dependency. Under pnpm a nested dep is not hoisted and only
-  // resolves from the dependent package's real `.pnpm` location.
+  // resolved from the roots of traced packages that declare it as a dependency,
+  // falling back to `rootDir` for app-level deps no traced package declares.
   // Driving this off declared dependencies (instead of trying every name against
   // every root) keeps it cheap even when a large allowlist is passed.
   // https://github.com/unjs/nf3/issues/49
   const traceIncludeSet = new Set((opts.traceInclude || []).filter((n) => !isAbsolute(n)));
   if (traceIncludeSet.size > 0) {
-    const resolveFrom = new Map<string, Set<string>>(
-      [...traceIncludeSet].map((name) => [name, new Set([rootDir])]),
+    // Collect the roots of traced packages that declare each requested name.
+    const declarerRoots = new Map<string, Set<string>>(
+      [...traceIncludeSet].map((name) => [name, new Set<string>()]),
     );
     for (const tracedPackage of Object.values(tracedPackages)) {
       for (const versionEntry of Object.values(tracedPackage.versions)) {
@@ -153,16 +153,20 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
           ...versionEntry.pkgJSON.optionalDependencies,
         };
         for (const depName of Object.keys(deps)) {
-          resolveFrom.get(depName)?.add(versionEntry.path);
+          declarerRoots.get(depName)?.add(versionEntry.path);
         }
       }
     }
-    for (const [name, froms] of resolveFrom) {
+    for (const [name, roots] of declarerRoots) {
       if (tracedPackages[name]) {
         continue;
       }
+      // Resolve from a declaring package's root first so we pick the instance the
+      // dependent actually uses (correct version, and pnpm's non-hoisted nested
+      // location). `rootDir` is only a fallback — otherwise an unrelated copy
+      // hoisted at the root could shadow the dependent's real dependency.
       let resolved: string | undefined;
-      for (const from of froms) {
+      for (const from of [...roots, rootDir]) {
         // Resolve the bare name (then derive the package root below). Resolving
         // `<name>/package.json` directly is unreliable since a package's
         // `exports` map usually does not expose it.

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,6 +1,6 @@
 import * as fsp from "node:fs/promises";
 import { nodeFileTrace } from "@vercel/nft";
-import { dirname, join, normalize, relative, resolve } from "pathe";
+import { dirname, isAbsolute, join, normalize, relative, resolve } from "pathe";
 import semver from "semver";
 import { resolveModulePath } from "exsolve";
 import { isWindows, parseNodeModulePath, readJSON, writeJSON } from "./_utils.ts";
@@ -14,10 +14,44 @@ export const DEFAULT_CONDITIONS = ["node", "import", "default"];
 export async function traceNodeModules(input: string[], opts: ExternalsTraceOptions) {
   const rootDir = resolve(opts.rootDir || ".");
 
-  await opts?.hooks?.traceStart?.(input);
+  // Force-include packages that may not be statically traceable (e.g. native
+  // deps loaded dynamically). Resolve each name from `rootDir`, falling back to
+  // the locations of the provided inputs. pnpm does not hoist transitive deps to
+  // the top-level node_modules, so they only resolve from the dependent
+  // package's real `.pnpm` location. https://github.com/unjs/nf3/issues/49
+  const allInput = [...input];
+  for (const name of opts.traceInclude || []) {
+    if (isAbsolute(name)) {
+      allInput.push(name);
+      continue;
+    }
+    let resolved = resolveModulePath(name, {
+      try: true,
+      from: rootDir,
+      conditions: opts.conditions,
+    });
+    for (const from of input) {
+      if (resolved) {
+        break;
+      }
+      // Resolve from the real path so resolution walks the real `.pnpm` tree
+      // rather than the symlinked one (where nested deps are not reachable).
+      const realFrom = await fsp.realpath(from).catch(() => from);
+      resolved = resolveModulePath(name, {
+        try: true,
+        from: realFrom,
+        conditions: opts.conditions,
+      });
+    }
+    if (resolved) {
+      allInput.push(resolved);
+    }
+  }
+
+  await opts?.hooks?.traceStart?.(allInput);
 
   // Trace used files using nft
-  const traceResult = await nodeFileTrace([...input], {
+  const traceResult = await nodeFileTrace([...allInput], {
     base: "/",
     exportsOnly: true,
     processCwd: rootDir,

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -133,24 +133,36 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
   }
 
   // Force-trace explicitly requested packages (`traceInclude`) that may not be
-  // statically reachable (e.g. native deps loaded dynamically). Resolve each
-  // name from `rootDir`, falling back to the already-traced package roots. Under
-  // pnpm a nested dep is not hoisted and only resolves from the dependent
-  // package's real `.pnpm` location. https://github.com/unjs/nf3/issues/49
-  const traceIncludeNames = (opts.traceInclude || []).filter((n) => !isAbsolute(n));
-  if (traceIncludeNames.length > 0) {
-    const fromCandidates = [
-      rootDir,
-      ...new Set(
-        Object.values(tracedPackages).flatMap((p) => Object.values(p.versions).map((v) => v.path)),
-      ),
-    ];
-    for (const name of traceIncludeNames) {
+  // statically reachable (e.g. native deps loaded dynamically). Each name is
+  // resolved from `rootDir` and from the roots of any traced package that
+  // declares it as a dependency. Under pnpm a nested dep is not hoisted and only
+  // resolves from the dependent package's real `.pnpm` location.
+  // Driving this off declared dependencies (instead of trying every name against
+  // every root) keeps it cheap even when a large allowlist is passed.
+  // https://github.com/unjs/nf3/issues/49
+  const traceIncludeSet = new Set((opts.traceInclude || []).filter((n) => !isAbsolute(n)));
+  if (traceIncludeSet.size > 0) {
+    const resolveFrom = new Map<string, Set<string>>(
+      [...traceIncludeSet].map((name) => [name, new Set([rootDir])]),
+    );
+    for (const tracedPackage of Object.values(tracedPackages)) {
+      for (const versionEntry of Object.values(tracedPackage.versions)) {
+        const deps = {
+          ...versionEntry.pkgJSON.dependencies,
+          ...versionEntry.pkgJSON.peerDependencies,
+          ...versionEntry.pkgJSON.optionalDependencies,
+        };
+        for (const depName of Object.keys(deps)) {
+          resolveFrom.get(depName)?.add(versionEntry.path);
+        }
+      }
+    }
+    for (const [name, froms] of resolveFrom) {
       if (tracedPackages[name]) {
         continue;
       }
       let resolved: string | undefined;
-      for (const from of fromCandidates) {
+      for (const from of froms) {
         // Resolve the bare name (then derive the package root below). Resolving
         // `<name>/package.json` directly is unreliable since a package's
         // `exports` map usually does not expose it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,10 +81,11 @@ export interface ExternalsTraceOptions {
    * not statically reachable from the input (e.g. native dependencies loaded
    * dynamically at runtime).
    *
-   * Each name is resolved from `rootDir` first, then from the locations of the
-   * provided input files. The latter makes it work with pnpm, which does not
-   * hoist transitive dependencies to the top-level `node_modules` — they can
-   * only be resolved from the dependent package's real `.pnpm` location.
+   * Each name is resolved from `rootDir` and from the roots of any traced
+   * package that declares it as a dependency. The latter makes it work with
+   * pnpm, which does not hoist transitive dependencies to the top-level
+   * `node_modules` — they can only be resolved from the dependent package's real
+   * `.pnpm` location.
    */
   traceInclude?: string[];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,11 +81,10 @@ export interface ExternalsTraceOptions {
    * not statically reachable from the input (e.g. native dependencies loaded
    * dynamically at runtime).
    *
-   * Each name is resolved from `rootDir` and from the roots of any traced
-   * package that declares it as a dependency. The latter makes it work with
-   * pnpm, which does not hoist transitive dependencies to the top-level
-   * `node_modules` — they can only be resolved from the dependent package's real
-   * `.pnpm` location.
+   * Each name is resolved from the roots of traced packages that declare it as a
+   * dependency (so the instance/version the dependent actually uses is picked,
+   * including pnpm's non-hoisted nested layout), falling back to `rootDir` for
+   * app-level deps that no traced package declares.
    */
   traceInclude?: string[];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,18 @@ export interface ExternalsTraceOptions {
   writePackageJson?: boolean;
 
   /**
+   * Package names (or absolute paths) to force into the trace even when they are
+   * not statically reachable from the input (e.g. native dependencies loaded
+   * dynamically at runtime).
+   *
+   * Each name is resolved from `rootDir` first, then from the locations of the
+   * provided input files. The latter makes it work with pnpm, which does not
+   * hoist transitive dependencies to the top-level `node_modules` — they can
+   * only be resolved from the dependent package's real `.pnpm` location.
+   */
+  traceInclude?: string[];
+
+  /**
    * List of package names to include all files for in the trace (not just nft-detected ones).
    *
    * Each item can be a package name string or a tuple of `[packageName, { glob }]` to customize the glob pattern.

--- a/test/fixture-pnpm/.gitignore
+++ b/test/fixture-pnpm/.gitignore
@@ -1,0 +1,9 @@
+# Force-commit the simulated pnpm node_modules layout (root .gitignore ignores node_modules)
+!node_modules
+
+# Symlinks recreated at test runtime (see test/pnpm.test.ts) — never commit them
+/node_modules/@fixture/pnpm-app
+/node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-native
+
+# Build output
+.output

--- a/test/fixture-pnpm/.gitignore
+++ b/test/fixture-pnpm/.gitignore
@@ -6,4 +6,4 @@
 /node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-native
 
 # Build output
-.output
+.output*

--- a/test/fixture-pnpm/index.mjs
+++ b/test/fixture-pnpm/index.mjs
@@ -1,0 +1,5 @@
+import app from "@fixture/pnpm-app";
+
+export default {
+  app,
+};

--- a/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app/index.mjs
+++ b/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app/index.mjs
@@ -1,0 +1,4 @@
+// Native dependency is loaded dynamically (like sharp/bcrypt resolve their
+// native binary at runtime), so it is NOT statically traceable by nft and must
+// be force-traced via `traceInclude` / nitro's `traceDeps`.
+export default "pnpm-app";

--- a/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app/package.json
+++ b/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/pnpm-app",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "@fixture/pnpm-native": "1.0.0"
+  }
+}

--- a/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native/index.mjs
+++ b/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native/index.mjs
@@ -1,0 +1,1 @@
+export default "pnpm-native";

--- a/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native/native.node
+++ b/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native/native.node
@@ -1,0 +1,2 @@
+; placeholder for a native .node binary that is loaded dynamically at runtime
+; and therefore only copied when the package is force-traced.

--- a/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native/package.json
+++ b/test/fixture-pnpm/node_modules/.pnpm/@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/pnpm-native",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixture-pnpm/node_modules/@fixture/pnpm-native/index.mjs
+++ b/test/fixture-pnpm/node_modules/@fixture/pnpm-native/index.mjs
@@ -1,0 +1,1 @@
+export default "pnpm-native-root-decoy";

--- a/test/fixture-pnpm/node_modules/@fixture/pnpm-native/package.json
+++ b/test/fixture-pnpm/node_modules/@fixture/pnpm-native/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/pnpm-native",
+  "version": "9.9.9",
+  "type": "module",
+  "exports": "./index.mjs",
+  "//": "Decoy: an unrelated copy hoisted at the project root. traceInclude must NOT pick this over the version pnpm-app actually depends on (1.0.0, nested in .pnpm). It deliberately has no native.node."
+}

--- a/test/pnpm.test.ts
+++ b/test/pnpm.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { fileURLToPath } from "node:url";
 import { builtinModules } from "node:module";
-import { lstat, mkdir, rm, symlink } from "node:fs/promises";
+import { lstat, mkdir, readFile, rm, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import * as rolldown from "rolldown";
 
@@ -16,8 +16,15 @@ import { traceNodeModules } from "../src/index.ts";
 // reached via symlinks. Because such packages load their native binary
 // dynamically, nft cannot statically trace them, so they must be force-traced
 // via `traceInclude` (nitro's `traceDeps`). Resolving those names only from
-// `rootDir` fails under pnpm; `traceInclude` must also resolve them from the
+// `rootDir` fails under pnpm; `traceInclude` must resolve them from the
 // dependent package's real `.pnpm` location.
+//
+// The fixture also has an unrelated decoy copy of the native dep hoisted at the
+// project root (`@fixture/pnpm-native@9.9.9`, no native.node). Resolution must
+// prefer the version `pnpm-app` actually depends on (1.0.0, nested in .pnpm)
+// over the root decoy.
+
+const NESTED_VERSION = "1.0.0";
 
 const fixtureDir = fileURLToPath(new URL("fixture-pnpm", import.meta.url));
 const nodeModules = `${fixtureDir}/node_modules`;
@@ -44,10 +51,23 @@ describe("pnpm .pnpm nested dependency tracing", () => {
       await rm(link, { force: true });
       await symlink(target, link, "dir");
     }
-    // Sanity check: the layout mirrors pnpm (native dep reachable only via .pnpm).
+    // Sanity check: the layout mirrors pnpm. pnpm-app is symlinked from the
+    // store, and the only top-level copy of the native dep is the decoy.
     expect((await lstat(`${nodeModules}/@fixture/pnpm-app`)).isSymbolicLink()).toBe(true);
-    expect(existsSync(`${nodeModules}/@fixture/pnpm-native`)).toBe(false);
+    const rootDecoy = JSON.parse(
+      await readFile(`${nodeModules}/@fixture/pnpm-native/package.json`, "utf8"),
+    );
+    expect(rootDecoy.version).toBe("9.9.9");
   });
+
+  async function expectTracedNativeVersion(nativeDir: string) {
+    expect(existsSync(nativeDir), "native package directory traced").toBe(true);
+    const traced = JSON.parse(await readFile(`${nativeDir}/package.json`, "utf8"));
+    expect(traced.version, "picks the dependent's nested version, not the root decoy").toBe(
+      NESTED_VERSION,
+    );
+    expect(existsSync(`${nativeDir}/native.node`), "native binary copied").toBe(true);
+  }
 
   it("traces a nested native dependency from the .pnpm store", async () => {
     const outDir = `${fixtureDir}/.output`;
@@ -61,21 +81,20 @@ describe("pnpm .pnpm nested dependency tracing", () => {
         externals({
           rootDir: fixtureDir,
           traceInclude: ["@fixture/pnpm-native"],
-          trace: { outDir, fullTraceInclude: ["@fixture/pnpm-native"] },
+          trace: { outDir },
         }),
       ],
     });
 
-    const nativeDir = `${outDir}/node_modules/@fixture/pnpm-native`;
-    expect(existsSync(nativeDir), "native package directory traced").toBe(true);
-    expect(existsSync(`${nativeDir}/native.node`), "native binary copied").toBe(true);
+    await expectTracedNativeVersion(`${outDir}/node_modules/@fixture/pnpm-native`);
   });
 
   // Root-cause coverage at the level nitro consumes nf3: nitro uses its own
   // externals plugin and only calls `traceNodeModules`, passing `traceDeps` as
   // names. The native dep here is NOT statically imported by pnpm-app, so it can
-  // only enter the trace via `traceInclude` resolved against the input location.
-  it("traceNodeModules resolves traceInclude against the .pnpm input location", async () => {
+  // only enter the trace via `traceInclude` resolved against the declaring
+  // package's root (not rootDir, where only the decoy lives).
+  it("traceNodeModules resolves traceInclude against the declaring package root", async () => {
     const outDir = `${fixtureDir}/.output-trace`;
     await rm(outDir, { recursive: true, force: true });
 
@@ -83,14 +102,9 @@ describe("pnpm .pnpm nested dependency tracing", () => {
     await traceNodeModules([appEntry], {
       rootDir: fixtureDir,
       outDir,
-      // resolves from rootDir (where it does NOT exist) -> falls back to the
-      // input package's real .pnpm location (where it does).
       traceInclude: ["@fixture/pnpm-native"],
-      fullTraceInclude: ["@fixture/pnpm-native"],
     });
 
-    const nativeDir = `${outDir}/node_modules/@fixture/pnpm-native`;
-    expect(existsSync(nativeDir), "native package directory traced").toBe(true);
-    expect(existsSync(`${nativeDir}/native.node`), "native binary copied").toBe(true);
+    await expectTracedNativeVersion(`${outDir}/node_modules/@fixture/pnpm-native`);
   });
 });

--- a/test/pnpm.test.ts
+++ b/test/pnpm.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+import { builtinModules } from "node:module";
+import { lstat, mkdir, rm, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import * as rolldown from "rolldown";
+
+import { externals } from "../src/plugin.ts";
+
+// Reproduction for https://github.com/unjs/nf3/issues/49
+//
+// pnpm does not hoist transitive dependencies to the top-level `node_modules`.
+// A native, non-bundleable dependency (e.g. `sharp` / `bcrypt`) that is only an
+// indirect dependency lives exclusively under `node_modules/.pnpm/...` and is
+// reached via symlinks. Because such packages load their native binary
+// dynamically, nft cannot statically trace them, so they must be force-traced
+// via `traceInclude` (nitro's `traceDeps`). nf3 resolves those names from
+// `rootDir`, where the package does not exist under pnpm — so tracing fails.
+
+const fixtureDir = fileURLToPath(new URL("fixture-pnpm", import.meta.url));
+const nodeModules = `${fixtureDir}/node_modules`;
+
+// Symlinks that pnpm would create on install. Recreated here so we don't have to
+// commit platform-fragile symlinks (see test/fixture-pnpm/.gitignore).
+const symlinks: [link: string, target: string][] = [
+  // top-level dependency -> its package in the virtual store
+  [
+    `${nodeModules}/@fixture/pnpm-app`,
+    "../.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app",
+  ],
+  // pnpm-app's nested (non-hoisted) native dependency
+  [
+    `${nodeModules}/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-native`,
+    "../../../@fixture+pnpm-native@1.0.0/node_modules/@fixture/pnpm-native",
+  ],
+];
+
+describe("pnpm .pnpm nested dependency tracing", () => {
+  beforeAll(async () => {
+    for (const [link, target] of symlinks) {
+      await mkdir(fileURLToPath(new URL(".", `file://${link}`)), { recursive: true });
+      await rm(link, { force: true });
+      await symlink(target, link, "dir");
+    }
+    // Sanity check: the layout mirrors pnpm (native dep reachable only via .pnpm).
+    expect((await lstat(`${nodeModules}/@fixture/pnpm-app`)).isSymbolicLink()).toBe(true);
+    expect(existsSync(`${nodeModules}/@fixture/pnpm-native`)).toBe(false);
+  });
+
+  it("traces a nested native dependency from the .pnpm store", async () => {
+    const outDir = `${fixtureDir}/.output`;
+    await rm(outDir, { recursive: true, force: true });
+
+    await rolldown.build({
+      input: `${fixtureDir}/index.mjs`,
+      output: { dir: outDir, format: "esm" },
+      external: [...builtinModules, ...builtinModules.map((m) => `node:${m}`)],
+      plugins: [
+        externals({
+          rootDir: fixtureDir,
+          traceInclude: ["@fixture/pnpm-native"],
+          trace: { outDir, fullTraceInclude: ["@fixture/pnpm-native"] },
+        }),
+      ],
+    });
+
+    const nativeDir = `${outDir}/node_modules/@fixture/pnpm-native`;
+    expect(existsSync(nativeDir), "native package directory traced").toBe(true);
+    expect(existsSync(`${nativeDir}/native.node`), "native binary copied").toBe(true);
+  });
+});

--- a/test/pnpm.test.ts
+++ b/test/pnpm.test.ts
@@ -6,16 +6,18 @@ import { existsSync } from "node:fs";
 import * as rolldown from "rolldown";
 
 import { externals } from "../src/plugin.ts";
+import { traceNodeModules } from "../src/index.ts";
 
-// Reproduction for https://github.com/unjs/nf3/issues/49
+// Regression test for https://github.com/unjs/nf3/issues/49
 //
 // pnpm does not hoist transitive dependencies to the top-level `node_modules`.
 // A native, non-bundleable dependency (e.g. `sharp` / `bcrypt`) that is only an
 // indirect dependency lives exclusively under `node_modules/.pnpm/...` and is
 // reached via symlinks. Because such packages load their native binary
 // dynamically, nft cannot statically trace them, so they must be force-traced
-// via `traceInclude` (nitro's `traceDeps`). nf3 resolves those names from
-// `rootDir`, where the package does not exist under pnpm — so tracing fails.
+// via `traceInclude` (nitro's `traceDeps`). Resolving those names only from
+// `rootDir` fails under pnpm; `traceInclude` must also resolve them from the
+// dependent package's real `.pnpm` location.
 
 const fixtureDir = fileURLToPath(new URL("fixture-pnpm", import.meta.url));
 const nodeModules = `${fixtureDir}/node_modules`;
@@ -62,6 +64,29 @@ describe("pnpm .pnpm nested dependency tracing", () => {
           trace: { outDir, fullTraceInclude: ["@fixture/pnpm-native"] },
         }),
       ],
+    });
+
+    const nativeDir = `${outDir}/node_modules/@fixture/pnpm-native`;
+    expect(existsSync(nativeDir), "native package directory traced").toBe(true);
+    expect(existsSync(`${nativeDir}/native.node`), "native binary copied").toBe(true);
+  });
+
+  // Root-cause coverage at the level nitro consumes nf3: nitro uses its own
+  // externals plugin and only calls `traceNodeModules`, passing `traceDeps` as
+  // names. The native dep here is NOT statically imported by pnpm-app, so it can
+  // only enter the trace via `traceInclude` resolved against the input location.
+  it("traceNodeModules resolves traceInclude against the .pnpm input location", async () => {
+    const outDir = `${fixtureDir}/.output-trace`;
+    await rm(outDir, { recursive: true, force: true });
+
+    const appEntry = `${nodeModules}/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app/index.mjs`;
+    await traceNodeModules([appEntry], {
+      rootDir: fixtureDir,
+      outDir,
+      // resolves from rootDir (where it does NOT exist) -> falls back to the
+      // input package's real .pnpm location (where it does).
+      traceInclude: ["@fixture/pnpm-native"],
+      fullTraceInclude: ["@fixture/pnpm-native"],
     });
 
     const nativeDir = `${outDir}/node_modules/@fixture/pnpm-native`;


### PR DESCRIPTION
Fixes #49

## Problem

pnpm does not hoist transitive dependencies to the top-level `node_modules`. A native, non-bundleable dependency (e.g. `sharp` / `bcrypt`) that is only an *indirect* dependency lives exclusively under `node_modules/.pnpm/...`. Such packages load their native binary dynamically, so nft can't statically trace them — they must be force-traced **by name** via `traceInclude` (nitro's `traceDeps`).

Those names were resolved **only from `rootDir`**, where the package doesn't exist under pnpm. So tracing either silently dropped the dep or threw `File .../<pkg> does not exist`. The documented workaround was pnpm's `publicHoistPattern`.

## Root cause & where the fix belongs

nitro consumes nf3 through its **own (forked) externals plugin** ([`src/build/plugins/externals.ts`](https://github.com/nitrojs/nitro/blob/main/src/build/plugins/externals.ts)) and only calls nf3's `traceNodeModules()`. So a plugin-only fix in nf3 would never reach nitro. The fix lives in the shared API, `traceNodeModules`:

- New `traceInclude?: string[]` option on `ExternalsTraceOptions`.
- Names are resolved **after** the traced packages are collected, against `rootDir` **and the deduplicated traced package roots**. Those roots are already `realpath`'d, so resolution walks the real `.pnpm` tree where pnpm's non-hoisted nested deps actually live.
- Resolution short-circuits on `rootDir` first (the common hoisted case), so it adds no meaningful overhead and — unlike an earlier iteration — does **not** scan the full `input` file list.
- Matched packages are full-traced (native deps load binaries dynamically, so an nft trace would miss them) and inserted **before** the `optionalDependencies` pass, so platform-specific bindings (e.g. sharp's `@img/*`) are picked up too.
- nf3's own plugin now delegates `traceInclude` to `traceNodeModules` instead of pre-resolving from `rootDir` (dropping a bogus fallback path that made nft throw).

### Follow-up needed in nitro

To benefit, nitro should pass its `traceDeps` names to `traceNodeModules` via the new `traceInclude` option (today they're used only as a bundler-side include filter). Happy to open that PR.

## Tests

`test/fixture-pnpm/` simulates a pnpm layout where the native dep is reachable only via `.pnpm` symlinks (recreated at runtime so no fragile symlinks are committed). `test/pnpm.test.ts` covers both consumption paths:

1. through the `externals` plugin with `traceInclude`;
2. directly through `traceNodeModules` (the path nitro uses), with the native dep **not** statically imported — it can only enter via `traceInclude` resolved against the `.pnpm` package root.

- `vitest run` — 32 passed
- `oxlint` / `oxfmt --check` — clean
- `tsgo --noEmit` — clean

## Commits

1. plugin-level `traceInclude` resolution against externalized parents (initial fix)
2. move the resolution into `traceNodeModules` (so nitro can use it via the shared API)
3. resolve against deduplicated traced package roots instead of the input file list (perf + correct placement before the optionalDependencies pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for forcing extra packages or paths to be included in tracing, even when they aren’t directly reachable at build time.
  * Tracing now better handles pnpm-style dependency layouts, including nested package resolution.

* **Bug Fixes**
  * Improved tracing of optional and nested dependencies so required files and native binaries are copied more reliably.
  * Fixed trace inclusion behavior to use the correct package root when resolving dependencies.

* **Tests**
  * Added regression coverage for pnpm-based tracing scenarios and forced trace inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->