### PR TITLE
fix(trace): follow transitive deps of traceInclude packages

### DIFF
--- a/src/trace.ts
+++ b/src/trace.ts
@@ -11,6 +11,7 @@ import {
   writeJSON,
 } from "./_utils.ts";
 
+import type { NodeFileTraceOptions } from "@vercel/nft";
 import type { PackageJson } from "pkg-types";
 import type { ExternalsTraceOptions, TracedFile, TracedPackage } from "./types.ts";
 export type { ExternalsTraceOptions } from "./types.ts";
@@ -23,6 +24,8 @@ const { nodeFileTrace } = nft;
 
 export const DEFAULT_CONDITIONS = ["node", "import", "default"];
 
+const JS_FILE_RE = /\.(?:c|m)?js$/;
+
 export async function traceNodeModules(input: string[], opts: ExternalsTraceOptions) {
   const rootDir = resolve(opts.rootDir || ".");
 
@@ -33,8 +36,11 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
   await opts?.hooks?.traceStart?.(allInput);
 
-  // Trace used files using nft
-  const traceResult = await nodeFileTrace([...allInput], {
+  const base = opts.nft?.base || "/";
+
+  // Shared nft options so the primary trace and the follow-up transitive trace
+  // (for force-included packages, below) resolve modules identically.
+  const nftOptions: NodeFileTraceOptions = {
     base: "/",
     exportsOnly: true,
     processCwd: rootDir,
@@ -43,116 +49,35 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
       (c) => !["require", "import", "default"].includes(c),
     ),
     ...opts.nft,
-  });
+  };
+
+  // Trace used files using nft
+  const traceResult = await nodeFileTrace([...allInput], nftOptions);
 
   await opts?.hooks?.traceResult?.(traceResult);
 
   // Resolve traced files
-  const _resolveTracedPath = async (p: string) => {
-    try {
-      return normalize(await fsp.realpath(resolve(opts.nft?.base || "/", p)));
-    } catch (error: any) {
-      if (error?.code === "ENOENT") {
-        return;
-      }
-      throw error;
-    }
-  };
-
-  const tracedFiles: Record<string, TracedFile> = Object.fromEntries(
-    (await Promise.all(
-      [...traceResult.reasons.entries()].map(async ([_path, reasons]) => {
-        if (reasons.ignored) {
-          return;
-        }
-        const path = await _resolveTracedPath(_path);
-        if (!path?.includes("node_modules")) {
-          return;
-        }
-        if (!(await isFile(path))) {
-          return;
-        }
-        const { dir: baseDir, name: pkgName, subpath } = parseNodeModulePath(path);
-        if (!baseDir || !pkgName) {
-          return;
-        }
-        const pkgPath = join(baseDir, pkgName);
-        const parents = (
-          await Promise.all([...reasons.parents].map((p) => _resolveTracedPath(p)))
-        ).filter((p): p is string => p !== undefined);
-        const tracedFile = <TracedFile>{
-          path,
-          parents,
-          subpath,
-          pkgName,
-          pkgPath,
-        };
-        return [path, tracedFile];
-      }),
-    ).then((r) => r.filter(Boolean))) as [string, TracedFile][],
-  );
+  const tracedFiles = await resolveTracedFiles(traceResult, base);
 
   await opts?.hooks?.tracedFiles?.(tracedFiles);
 
   // Resolve traced packages
   const tracedPackages: Record<string, TracedPackage> = {};
   const pkgCache: Map<string, PackageJson> = new Map();
-  for (const tracedFile of Object.values(tracedFiles)) {
-    // Use `node_modules/{name}` in path as name to support aliases
-    const pkgName = tracedFile.pkgName;
-    let tracedPackage = tracedPackages[pkgName];
-    let pkgJSON = pkgCache.get(tracedFile.pkgPath) as PackageJson;
-    if (!pkgJSON) {
-      pkgJSON = await readJSON(join(tracedFile.pkgPath, "package.json")).catch(() => {
-        return { name: pkgName, version: "0.0.0" };
-      });
-      pkgCache.set(tracedFile.pkgPath, pkgJSON);
-    }
+  // Every file already assigned to a package, so the follow-up transitive trace
+  // for force-included packages (below) does not re-add duplicates.
+  const seenFiles = new Set<string>();
+  await indexTracedFiles(Object.values(tracedFiles), {
+    tracedFiles,
+    tracedPackages,
+    pkgCache,
+    seenFiles,
+    fullTraceInclude: opts.fullTraceInclude,
+  });
 
-    if (!tracedPackage) {
-      tracedPackage = {
-        name: pkgName,
-        versions: {},
-      };
-      tracedPackages[pkgName] = tracedPackage;
-    }
-    let tracedPackageVersion = tracedPackage.versions[pkgJSON.version || "0.0.0"];
-    if (!tracedPackageVersion) {
-      tracedPackageVersion = {
-        path: tracedFile.pkgPath,
-        files: [],
-        pkgJSON,
-      };
-      tracedPackage.versions[pkgJSON.version || "0.0.0"] = tracedPackageVersion;
-
-      const fullTraceEntry = resolveFullTraceEntry(opts.fullTraceInclude, pkgName);
-      if (fullTraceEntry) {
-        if (fullTraceEntry.glob) {
-          if (!fsp.glob) {
-            throw new Error(
-              "`fullTraceInclude` glob requires Node.js >= 22.0.0 (fs.promises.glob)",
-            );
-          }
-          for await (const file of fsp.glob(fullTraceEntry.glob, {
-            cwd: tracedFile.pkgPath,
-            exclude: (name) => name === "node_modules",
-          })) {
-            const fullPath = join(tracedFile.pkgPath, file);
-            if (await isFile(fullPath)) {
-              tracedPackageVersion.files.push(fullPath);
-            }
-          }
-        } else {
-          tracedPackageVersion.files.push(...(await listPkgFiles(tracedFile.pkgPath)));
-        }
-      }
-    }
-    tracedPackageVersion.files.push(tracedFile.path);
-    tracedFile.pkgName = pkgName;
-    if (pkgJSON.version) {
-      tracedFile.pkgVersion = pkgJSON.version;
-    }
-  }
+  // JS files of force-included packages, traced transitively below so their
+  // runtime dependencies get copied too.
+  const transitiveInput: string[] = [];
 
   // Force-trace explicitly requested packages (`traceInclude`) that may not be
   // statically reachable (e.g. native deps loaded dynamically). Each name is
@@ -226,7 +151,32 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
           },
         },
       };
+      // The package's own files are copied wholesale, but nft never followed
+      // their imports — so queue the JS files for a transitive trace (below) to
+      // pull in runtime deps (e.g. `meriyah` for orchestrion). Mark them seen so
+      // that trace doesn't re-add them.
+      for (const file of files) {
+        seenFiles.add(file);
+        if (JS_FILE_RE.test(file)) {
+          transitiveInput.push(file);
+        }
+      }
     }
+  }
+
+  // Follow transitive dependencies of force-included packages. Runs before the
+  // optionalDependencies pass so newly discovered packages get their optional
+  // (native) deps auto-included too. https://github.com/nodejs/orchestrion-js/issues/80
+  if (transitiveInput.length > 0) {
+    const transitiveResult = await nodeFileTrace(transitiveInput, nftOptions);
+    const transitiveFiles = await resolveTracedFiles(transitiveResult, base);
+    await indexTracedFiles(Object.values(transitiveFiles), {
+      tracedFiles,
+      tracedPackages,
+      pkgCache,
+      seenFiles,
+      fullTraceInclude: opts.fullTraceInclude,
+    });
   }
 
   // Auto-detect and full-trace optionalDependencies (e.g. platform-specific native bindings)
@@ -471,6 +421,130 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
         ].sort(([a], [b]) => a!.localeCompare(b!)),
       ),
     });
+  }
+}
+
+async function resolveTracedPath(base: string, p: string) {
+  try {
+    return normalize(await fsp.realpath(resolve(base, p)));
+  } catch (error: any) {
+    if (error?.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+/** Turn an nft trace result into a `path -> TracedFile` map (node_modules only). */
+async function resolveTracedFiles(
+  traceResult: Awaited<ReturnType<typeof nodeFileTrace>>,
+  base: string,
+): Promise<Record<string, TracedFile>> {
+  return Object.fromEntries(
+    (await Promise.all(
+      [...traceResult.reasons.entries()].map(async ([_path, reasons]) => {
+        if (reasons.ignored) {
+          return;
+        }
+        const path = await resolveTracedPath(base, _path);
+        if (!path?.includes("node_modules")) {
+          return;
+        }
+        if (!(await isFile(path))) {
+          return;
+        }
+        const { dir: baseDir, name: pkgName, subpath } = parseNodeModulePath(path);
+        if (!baseDir || !pkgName) {
+          return;
+        }
+        const pkgPath = join(baseDir, pkgName);
+        const parents = (
+          await Promise.all([...reasons.parents].map((p) => resolveTracedPath(base, p)))
+        ).filter((p): p is string => p !== undefined);
+        const tracedFile = <TracedFile>{ path, parents, subpath, pkgName, pkgPath };
+        return [path, tracedFile];
+      }),
+    ).then((r) => r.filter(Boolean))) as [string, TracedFile][],
+  );
+}
+
+/**
+ * Group traced files into `tracedPackages` by name/version. Idempotent across
+ * calls via `seenFiles`, so a follow-up transitive trace can merge new files
+ * without re-adding ones already assigned.
+ */
+async function indexTracedFiles(
+  files: TracedFile[],
+  ctx: {
+    tracedFiles: Record<string, TracedFile>;
+    tracedPackages: Record<string, TracedPackage>;
+    pkgCache: Map<string, PackageJson>;
+    seenFiles: Set<string>;
+    fullTraceInclude: ExternalsTraceOptions["fullTraceInclude"];
+  },
+) {
+  const { tracedFiles, tracedPackages, pkgCache, seenFiles, fullTraceInclude } = ctx;
+  for (const tracedFile of files) {
+    if (seenFiles.has(tracedFile.path)) {
+      continue;
+    }
+    seenFiles.add(tracedFile.path);
+    tracedFiles[tracedFile.path] = tracedFile;
+
+    // Use `node_modules/{name}` in path as name to support aliases
+    const pkgName = tracedFile.pkgName;
+    let tracedPackage = tracedPackages[pkgName];
+    let pkgJSON = pkgCache.get(tracedFile.pkgPath) as PackageJson;
+    if (!pkgJSON) {
+      pkgJSON = await readJSON(join(tracedFile.pkgPath, "package.json")).catch(() => {
+        return { name: pkgName, version: "0.0.0" };
+      });
+      pkgCache.set(tracedFile.pkgPath, pkgJSON);
+    }
+
+    if (!tracedPackage) {
+      tracedPackage = {
+        name: pkgName,
+        versions: {},
+      };
+      tracedPackages[pkgName] = tracedPackage;
+    }
+    let tracedPackageVersion = tracedPackage.versions[pkgJSON.version || "0.0.0"];
+    if (!tracedPackageVersion) {
+      tracedPackageVersion = {
+        path: tracedFile.pkgPath,
+        files: [],
+        pkgJSON,
+      };
+      tracedPackage.versions[pkgJSON.version || "0.0.0"] = tracedPackageVersion;
+
+      const fullTraceEntry = resolveFullTraceEntry(fullTraceInclude, pkgName);
+      if (fullTraceEntry) {
+        if (fullTraceEntry.glob) {
+          if (!fsp.glob) {
+            throw new Error(
+              "`fullTraceInclude` glob requires Node.js >= 22.0.0 (fs.promises.glob)",
+            );
+          }
+          for await (const file of fsp.glob(fullTraceEntry.glob, {
+            cwd: tracedFile.pkgPath,
+            exclude: (name) => name === "node_modules",
+          })) {
+            const fullPath = join(tracedFile.pkgPath, file);
+            if (await isFile(fullPath)) {
+              tracedPackageVersion.files.push(fullPath);
+            }
+          }
+        } else {
+          tracedPackageVersion.files.push(...(await listPkgFiles(tracedFile.pkgPath)));
+        }
+      }
+    }
+    tracedPackageVersion.files.push(tracedFile.path);
+    tracedFile.pkgName = pkgName;
+    if (pkgJSON.version) {
+      tracedFile.pkgVersion = pkgJSON.version;
+    }
   }
 }
 

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -36,12 +36,15 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
   await opts?.hooks?.traceStart?.(allInput);
 
-  const base = opts.nft?.base || "/";
+  // Resolve the trace base once and reuse it everywhere: the primary trace, the
+  // follow-up transitive trace, and reason-path resolution (`resolveTracedPath`)
+  // must all agree on it. Deriving it separately let an explicit `nft.base: ""`
+  // reach `nodeFileTrace` while path resolution silently fell back to "/".
+  const base = opts.nft?.base ?? "/";
 
   // Shared nft options so the primary trace and the follow-up transitive trace
   // (for force-included packages, below) resolve modules identically.
   const nftOptions: NodeFileTraceOptions = {
-    base: "/",
     exportsOnly: true,
     processCwd: rootDir,
     // https://github.com/nitrojs/nitro/pull/1562
@@ -49,6 +52,7 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
       (c) => !["require", "import", "default"].includes(c),
     ),
     ...opts.nft,
+    base,
   };
 
   // Trace used files using nft
@@ -58,8 +62,6 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
 
   // Resolve traced files
   const tracedFiles = await resolveTracedFiles(traceResult, base);
-
-  await opts?.hooks?.tracedFiles?.(tracedFiles);
 
   // Resolve traced packages
   const tracedPackages: Record<string, TracedPackage> = {};
@@ -152,13 +154,44 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
         },
       };
       // The package's own files are copied wholesale, but nft never followed
-      // their imports — so queue the JS files for a transitive trace (below) to
-      // pull in runtime deps (e.g. `meriyah` for orchestrion). Mark them seen so
-      // that trace doesn't re-add them.
+      // their imports — so queue its runtime entry points for a transitive trace
+      // (below) to pull in runtime deps (e.g. `meriyah` for orchestrion). Only
+      // declared entries are followed: tracing every shipped `.js` would also
+      // follow imports from dev-only files (tests, `*.config.mjs`, build scripts)
+      // and drag their devDependencies into the output. Empty ⇒ fall back to all
+      // JS files (packages with no declared entry still need their deps traced).
+      const entryFiles = pkgEntryFiles(depPkgJSON, depPath, files);
       for (const file of files) {
+        // Realpath every file into `seenFiles` (not just the raw path) so the
+        // transitive trace below — which reports canonical realpath keys — does
+        // not re-index and re-copy the package's own files under symlinked
+        // (pnpm) layouts, where the raw and canonical paths differ.
+        const path = await resolveTracedPath(base, file);
         seenFiles.add(file);
-        if (JS_FILE_RE.test(file)) {
+        if (path) {
+          seenFiles.add(path);
+        }
+        if (!JS_FILE_RE.test(file)) {
+          continue;
+        }
+        if (entryFiles.size === 0 || entryFiles.has(file)) {
           transitiveInput.push(file);
+        }
+        // Register the JS file in `tracedFiles` under its canonical (realpath)
+        // key. Transitive deps discovered below record their parent as one of
+        // these files, and `findPackageParents` resolves parents through
+        // `tracedFiles`; without this the force-included package is dropped as a
+        // parent, so multi-version dedup never links the dep under it and it
+        // resolves to whichever version got hoisted at runtime.
+        if (path) {
+          tracedFiles[path] = <TracedFile>{
+            path,
+            parents: [],
+            subpath: parseNodeModulePath(path).subpath,
+            pkgName: name,
+            pkgVersion: depVersion,
+            pkgPath: depPath,
+          };
         }
       }
     }
@@ -168,16 +201,31 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
   // optionalDependencies pass so newly discovered packages get their optional
   // (native) deps auto-included too. https://github.com/nodejs/orchestrion-js/issues/80
   if (transitiveInput.length > 0) {
-    const transitiveResult = await nodeFileTrace(transitiveInput, nftOptions);
-    const transitiveFiles = await resolveTracedFiles(transitiveResult, base);
-    await indexTracedFiles(Object.values(transitiveFiles), {
-      tracedFiles,
-      tracedPackages,
-      pkgCache,
-      seenFiles,
-      fullTraceInclude: opts.fullTraceInclude,
-    });
+    try {
+      const transitiveResult = await nodeFileTrace(transitiveInput, nftOptions);
+      // Pass `seenFiles` so already-indexed files are dropped before the
+      // realpath/stat work in `resolveTracedFiles`, not after.
+      const transitiveFiles = await resolveTracedFiles(transitiveResult, base, seenFiles);
+      await indexTracedFiles(Object.values(transitiveFiles), {
+        tracedFiles,
+        tracedPackages,
+        pkgCache,
+        seenFiles,
+        fullTraceInclude: opts.fullTraceInclude,
+      });
+    } catch (error) {
+      // The follow-up trace parses the force-included packages' JS through nft.
+      // A parser/resolver failure there must not abort the whole build — the
+      // packages themselves are still copied wholesale, so degrade to the
+      // pre-transitive behaviour instead of throwing.
+      console.error(
+        "nf3: failed to trace transitive dependencies of `traceInclude` packages",
+        error,
+      );
+    }
   }
+
+  await opts?.hooks?.tracedFiles?.(tracedFiles);
 
   // Auto-detect and full-trace optionalDependencies (e.g. platform-specific native bindings)
   for (const tracedPackage of Object.values(tracedPackages)) {
@@ -439,6 +487,7 @@ async function resolveTracedPath(base: string, p: string) {
 async function resolveTracedFiles(
   traceResult: Awaited<ReturnType<typeof nodeFileTrace>>,
   base: string,
+  seen?: Set<string>,
 ): Promise<Record<string, TracedFile>> {
   return Object.fromEntries(
     (await Promise.all(
@@ -448,6 +497,11 @@ async function resolveTracedFiles(
         }
         const path = await resolveTracedPath(base, _path);
         if (!path?.includes("node_modules")) {
+          return;
+        }
+        // Skip files already assigned to a package (e.g. by the primary trace)
+        // before the remaining stat/realpath work below.
+        if (seen?.has(path)) {
           return;
         }
         if (!(await isFile(path))) {
@@ -590,6 +644,47 @@ function resolveFullTraceEntry(
     }
   }
   return undefined;
+}
+
+/** Collect every string leaf of a package.json `exports` field. */
+function collectExportTargets(node: PackageJson["exports"], out: string[]) {
+  if (typeof node === "string") {
+    out.push(node);
+  } else if (Array.isArray(node)) {
+    for (const item of node) collectExportTargets(item, out);
+  } else if (node && typeof node === "object") {
+    for (const value of Object.values(node)) collectExportTargets(value, out);
+  }
+}
+
+/**
+ * Runtime entry points a package declares (`main`, `module`, `exports`, `bin`),
+ * resolved to absolute paths and restricted to the JS files we are copying. Used
+ * to seed the transitive trace so only entry-reachable imports are followed —
+ * not imports from a package's dev/test/config files.
+ */
+function pkgEntryFiles(pkgJSON: PackageJson, pkgPath: string, files: string[]): Set<string> {
+  const targets: string[] = [];
+  if (typeof pkgJSON.main === "string") targets.push(pkgJSON.main);
+  if (typeof pkgJSON.module === "string") targets.push(pkgJSON.module);
+  collectExportTargets(pkgJSON.exports, targets);
+  const bin = pkgJSON.bin;
+  if (typeof bin === "string") {
+    targets.push(bin);
+  } else if (bin && typeof bin === "object") {
+    for (const value of Object.values(bin)) {
+      if (typeof value === "string") targets.push(value);
+    }
+  }
+  const fileSet = new Set(files);
+  const entries = new Set<string>();
+  for (const target of targets) {
+    const abs = join(pkgPath, target);
+    if (JS_FILE_RE.test(abs) && fileSet.has(abs)) {
+      entries.add(abs);
+    }
+  }
+  return entries;
 }
 
 async function listPkgFiles(dir: string): Promise<string[]> {

--- a/test/fixture/force-include-dev.mjs
+++ b/test/fixture/force-include-dev.mjs
@@ -1,0 +1,4 @@
+// The app never statically imports `@fixture/force-included-dev`; it is
+// force-traced via `traceInclude`. That package ships a runtime entry and a
+// dev-only `build.config.mjs`; only the former's imports should be followed.
+export default "app";

--- a/test/fixture/force-include-mv.mjs
+++ b/test/fixture/force-include-mv.mjs
@@ -1,0 +1,8 @@
+// The app statically imports `@fixture/mv-dep` at v2.0.0 (hoisted at the top
+// level), while `@fixture/force-included-mv` — pulled in only via `traceInclude`
+// — depends on `@fixture/mv-dep` at v1.0.0 (nested). This makes `mv-dep`
+// multi-version, exercising the dedup path where the force-included package must
+// be attributed as the parent of its own runtime dependency.
+import dep from "@fixture/mv-dep";
+
+export default dep;

--- a/test/fixture/force-include.mjs
+++ b/test/fixture/force-include.mjs
@@ -1,0 +1,3 @@
+// The app never statically imports `@fixture/force-included`; it is force-traced
+// via `traceInclude` (as nitro does for runtime-loaded instrumentation).
+export default "app";

--- a/test/fixture/node_modules/@fixture/force-included-dev/build.config.mjs
+++ b/test/fixture/node_modules/@fixture/force-included-dev/build.config.mjs
@@ -1,0 +1,5 @@
+// Dev-only config, shipped in the package but never loaded at runtime. Tracing
+// it would drag `@fixture/dev-dep` into the production output.
+import dep from "@fixture/dev-dep";
+
+export default dep;

--- a/test/fixture/node_modules/@fixture/force-included-dev/index.mjs
+++ b/test/fixture/node_modules/@fixture/force-included-dev/index.mjs
@@ -1,0 +1,4 @@
+// Runtime entry point (declared via `exports`). Its imports must be followed.
+import dep from "@fixture/runtime-dep";
+
+export default dep;

--- a/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/dev-dep/index.mjs
+++ b/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/dev-dep/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/dev-dep@1.0.0";

--- a/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/dev-dep/package.json
+++ b/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/dev-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/dev-dep",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/runtime-dep/index.mjs
+++ b/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/runtime-dep/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/runtime-dep@1.0.0";

--- a/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/runtime-dep/package.json
+++ b/test/fixture/node_modules/@fixture/force-included-dev/node_modules/@fixture/runtime-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/runtime-dep",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/node_modules/@fixture/force-included-dev/package.json
+++ b/test/fixture/node_modules/@fixture/force-included-dev/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fixture/force-included-dev",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "@fixture/runtime-dep": "1.0.0"
+  },
+  "devDependencies": {
+    "@fixture/dev-dep": "1.0.0"
+  }
+}

--- a/test/fixture/node_modules/@fixture/force-included-mv/index.mjs
+++ b/test/fixture/node_modules/@fixture/force-included-mv/index.mjs
@@ -1,0 +1,7 @@
+// Loaded at runtime (e.g. via `node --import`), never statically imported by the
+// app entry — so it enters the trace only through `traceInclude`. It depends on
+// its own (older) version of `@fixture/mv-dep`, which must be linked under this
+// package rather than resolving to the version hoisted at the top level.
+import dep from "@fixture/mv-dep";
+
+export default `@fixture/force-included-mv@1.0.0+${dep}`;

--- a/test/fixture/node_modules/@fixture/force-included-mv/node_modules/@fixture/mv-dep/index.mjs
+++ b/test/fixture/node_modules/@fixture/force-included-mv/node_modules/@fixture/mv-dep/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/mv-dep@1.0.0";

--- a/test/fixture/node_modules/@fixture/force-included-mv/node_modules/@fixture/mv-dep/package.json
+++ b/test/fixture/node_modules/@fixture/force-included-mv/node_modules/@fixture/mv-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/mv-dep",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/node_modules/@fixture/force-included-mv/package.json
+++ b/test/fixture/node_modules/@fixture/force-included-mv/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/force-included-mv",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "@fixture/mv-dep": "1.0.0"
+  }
+}

--- a/test/fixture/node_modules/@fixture/force-included/index.mjs
+++ b/test/fixture/node_modules/@fixture/force-included/index.mjs
@@ -1,0 +1,6 @@
+// Loaded at runtime (e.g. via `node --import`), never statically imported by the
+// app entry — so it enters the trace only through `traceInclude`. Its runtime
+// dependency (and that dependency's own dependency) must be followed too.
+import a from "@fixture/transitive-a";
+
+export default `@fixture/force-included@1.0.0+${a}`;

--- a/test/fixture/node_modules/@fixture/force-included/package.json
+++ b/test/fixture/node_modules/@fixture/force-included/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/force-included",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "@fixture/transitive-a": "1.0.0"
+  }
+}

--- a/test/fixture/node_modules/@fixture/mv-dep/index.mjs
+++ b/test/fixture/node_modules/@fixture/mv-dep/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/mv-dep@2.0.0";

--- a/test/fixture/node_modules/@fixture/mv-dep/package.json
+++ b/test/fixture/node_modules/@fixture/mv-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/mv-dep",
+  "version": "2.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/node_modules/@fixture/transitive-a/index.mjs
+++ b/test/fixture/node_modules/@fixture/transitive-a/index.mjs
@@ -1,0 +1,3 @@
+import b from "@fixture/transitive-b";
+
+export default `@fixture/transitive-a@1.0.0+${b}`;

--- a/test/fixture/node_modules/@fixture/transitive-a/package.json
+++ b/test/fixture/node_modules/@fixture/transitive-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/transitive-a",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "@fixture/transitive-b": "1.0.0"
+  }
+}

--- a/test/fixture/node_modules/@fixture/transitive-b/index.mjs
+++ b/test/fixture/node_modules/@fixture/transitive-b/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/transitive-b@1.0.0";

--- a/test/fixture/node_modules/@fixture/transitive-b/package.json
+++ b/test/fixture/node_modules/@fixture/transitive-b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/transitive-b",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -83,6 +83,65 @@ describe("traceNodeModules", () => {
     await expect(stat(path.join(scope, "transitive-b", "index.mjs"))).resolves.toBeTruthy();
   });
 
+  // Regression for the multi-version dedup of a traceInclude package's own
+  // runtime dependency. `@fixture/force-included-mv` (force-traced) needs
+  // `@fixture/mv-dep@1.0.0`, while the app statically imports `@fixture/mv-dep@2.0.0`.
+  // The force-included package's files must be attributed as the parent of its
+  // transitive dep so dedup links v1.0.0 under it — otherwise it resolves the
+  // hoisted v2.0.0 at runtime.
+  it("dedups a traceInclude package's own multi-version dependency", async () => {
+    const rootDir = fileURLToPath(new URL("fixture", import.meta.url));
+    const input = fileURLToPath(new URL("fixture/force-include-mv.mjs", import.meta.url));
+    const outDir = fileURLToPath(new URL("dist/force-include-mv", import.meta.url));
+
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+    await cp(input, `${outDir}/force-include-mv.mjs`);
+
+    await traceNodeModules([input], {
+      rootDir,
+      outDir,
+      traceInclude: ["@fixture/force-included-mv"],
+    });
+
+    // The app entry resolves the hoisted (newer) version at the top level.
+    const app = await import(`${outDir}/force-include-mv.mjs`);
+    expect(app.default).toBe("@fixture/mv-dep@2.0.0");
+
+    // The force-included package must still resolve its own (older) version,
+    // linked under its `node_modules` rather than falling back to the hoisted one.
+    const forceIncluded = await import(
+      path.join(outDir, "node_modules", "@fixture", "force-included-mv", "index.mjs")
+    );
+    expect(forceIncluded.default).toBe("@fixture/force-included-mv@1.0.0+@fixture/mv-dep@1.0.0");
+  });
+
+  // The transitive trace of a traceInclude package must follow only its declared
+  // runtime entry points, not every shipped `.js`. `@fixture/force-included-dev`
+  // ships a `build.config.mjs` importing a devDependency that its runtime entry
+  // never touches; that devDependency must stay out of the output.
+  it("does not follow dev-only files when tracing a traceInclude package", async () => {
+    const rootDir = fileURLToPath(new URL("fixture", import.meta.url));
+    const input = fileURLToPath(new URL("fixture/force-include-dev.mjs", import.meta.url));
+    const outDir = fileURLToPath(new URL("dist/force-include-dev", import.meta.url));
+
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+    await cp(input, `${outDir}/force-include-dev.mjs`);
+
+    await traceNodeModules([input], {
+      rootDir,
+      outDir,
+      traceInclude: ["@fixture/force-included-dev"],
+    });
+
+    const scope = path.join(outDir, "node_modules", "@fixture");
+    // The runtime dependency (reachable from the entry) is traced and copied...
+    await expect(stat(path.join(scope, "runtime-dep", "index.mjs"))).resolves.toBeTruthy();
+    // ...but the devDependency, only reachable from `build.config.mjs`, is not.
+    await expect(stat(path.join(scope, "dev-dep"))).rejects.toThrow();
+  });
+
   // Regression for https://github.com/unjs/nf3/issues/47
   // `@fixture/native-libvips` mirrors `@img/sharp-libvips-*`: it is declared only
   // as an `optionalDependency` (loaded at runtime via native `@rpath` links, with

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -53,6 +53,36 @@ describe("traceNodeModules", () => {
     ).toMatch("# Title");
   });
 
+  // Regression for https://github.com/nodejs/orchestrion-js/issues/80
+  // A package force-included via `traceInclude` (e.g. orchestrion, loaded at
+  // runtime through `node --import` rather than statically imported) is copied
+  // whole, but its runtime dependencies must be followed transitively too —
+  // otherwise the output crashes at runtime with a missing module (e.g. the
+  // `meriyah` parser that orchestrion requires).
+  it("traces transitive dependencies of a traceInclude package", async () => {
+    const rootDir = fileURLToPath(new URL("fixture", import.meta.url));
+    const input = fileURLToPath(new URL("fixture/force-include.mjs", import.meta.url));
+    const outDir = fileURLToPath(new URL("dist/force-include", import.meta.url));
+
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+    await cp(input, `${outDir}/force-include.mjs`);
+
+    await traceNodeModules([input], {
+      rootDir,
+      outDir,
+      traceInclude: ["@fixture/force-included"],
+    });
+
+    const scope = path.join(outDir, "node_modules", "@fixture");
+    // The force-included package itself is copied...
+    await expect(stat(path.join(scope, "force-included", "index.mjs"))).resolves.toBeTruthy();
+    // ...along with its direct runtime dependency...
+    await expect(stat(path.join(scope, "transitive-a", "index.mjs"))).resolves.toBeTruthy();
+    // ...and the transitive-of-transitive dependency.
+    await expect(stat(path.join(scope, "transitive-b", "index.mjs"))).resolves.toBeTruthy();
+  });
+
   // Regression for https://github.com/unjs/nf3/issues/47
   // `@fixture/native-libvips` mirrors `@img/sharp-libvips-*`: it is declared only
   // as an `optionalDependency` (loaded at runtime via native `@rpath` links, with


### PR DESCRIPTION
## Problem

Packages force-included via `traceInclude` are copied wholesale, but nft never followed their imports — so their **transitive runtime dependencies were dropped** from the output. The traced app then crashes at runtime with a missing module.

This is the orchestrion-js / Nitro bundling failure ([nodejs/orchestrion-js#80](https://github.com/nodejs/orchestrion-js/issues/80), [nitrojs/nitro#2923](https://github.com/nitrojs/nitro/issues/2923)): orchestrion (`@apm-js-collab/code-transformer`) is loaded at runtime via `node --import` (so it's force-included, not statically imported) and requires `meriyah`. The upstream workaround was to hard-code `vercel.nft.include: ["node_modules/meriyah/dist/**/*"]` in the package's own `package.json` — a field only Vercel's NFT consumer reads.

### Reproduced standalone

Force-including `@apm-js-collab/code-transformer` via `traceInclude`, then running the output in an isolated `node_modules`:

```
@apm-js-collab/code-transformer   ✅ INCLUDED   (force-included)
├── astring                       ❌ MISSING
├── esquery                       ❌ MISSING
├── meriyah                       ❌ MISSING
├── semifies                      ❌ MISSING
└── source-map                    ❌ MISSING
→ RUNTIME ERROR: Cannot find module 'esquery'
```

The normal (static-import) trace path was never affected — nft follows the whole graph there. Only the force-include path dropped deps.

## Fix

- Extract the traced-files / traced-packages construction into reusable, idempotent helpers (`resolveTracedFiles`, `indexTracedFiles`), deduped via a shared `seenFiles` set.
- After a `traceInclude` package's own files are copied (kept as-is, for native/dynamic safety), run a follow-up nft pass over its JS entry points and merge the discovered `node_modules` files into `tracedPackages`.
- The pass runs **before** the `optionalDependencies` step, so transitively-discovered packages get their native optional deps auto-included too.
- Both nft passes share one options object so resolution (conditions, `exportsOnly`, `base`) is identical.

After the fix, all five deps are copied (`estraverse` is correctly omitted — esquery's published `main` bundles it), and the output loads in a clean isolated `node_modules`.

### Correct scope and attribution

The transitive trace is careful about *what* it follows and *how* discovered deps are attributed:

- **Only declared runtime entries are followed** (`main` / `module` / `exports` / `bin`), not every shipped `.js`. Tracing all files would follow imports from dev-only files (tests, `*.config.mjs`, build scripts) and drag their devDependencies into the output. Packages that declare no entry fall back to all JS files (they still need their deps traced).
- **Force-included files are registered in `tracedFiles` under their canonical (realpath) key**, so a transitive dep records the force-included package as its parent. Without this, multi-version dedup drops it as a parent and the dep resolves to whichever version got hoisted at runtime. Realpath keying also prevents re-indexing/re-copying the package's own files under symlinked (pnpm) layouts.
- **The trace `base` is resolved once and shared** across the primary trace, the transitive trace, and reason-path resolution. Previously an explicit `nft.base` could reach `nodeFileTrace` while path resolution silently fell back to `"/"`.
- **The follow-up pass is fault-tolerant**: a parser/resolver failure while re-parsing a force-included package's JS logs a warning and degrades to pre-transitive behaviour (the package itself is still copied wholesale) instead of aborting the build.

## Tests

Three regression tests in `test/trace.test.ts`, each with purpose-built fixtures:

- **Transitive chain** — a force-included package → runtime dep → grandchild dep are all copied. Mirrors the orchestrion→`meriyah` case; verified it **fails without** the fix (`ENOENT` on the transitive dep) and **passes with** it.
- **Multi-version dedup** — a force-included package needs its own (older) version of a dep while the app statically imports a newer (hoisted) one; the force-included package must be attributed as parent so its version is linked under it rather than resolving the hoisted one.
- **Entry-only scope** — a force-included package ships a dev-only `build.config.mjs` importing a devDependency its runtime entry never touches; that devDependency must stay out of the output.

Full suite, typecheck, `oxlint`, and `oxfmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
