### PR TITLE
feat(trace): add `traceIncludeRoots` for bundled declarers

### DIFF
--- a/src/trace.ts
+++ b/src/trace.ts
@@ -120,10 +120,18 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
     // declare `traceInclude` names — e.g. a package the caller bundles that
     // dynamically loads a native dependency. Without these, such names only
     // resolve from `rootDir`, which fails under pnpm's non-hoisted layout.
-    for (const root of new Set(opts.traceIncludeRoots || [])) {
-      const pkgJSON = await readJSON(join(root, "package.json")).catch(() => null);
-      addDeclarer(pkgJSON, root);
-    }
+    // Normalize against `rootDir` so relative roots resolve predictably (an
+    // unresolved relative path would read the wrong `package.json` and be a
+    // silent no-op). Reads are independent, so run them concurrently.
+    const includeRoots = [...new Set(opts.traceIncludeRoots || [])].map((root) =>
+      resolve(rootDir, root),
+    );
+    await Promise.all(
+      includeRoots.map(async (root) => {
+        const pkgJSON = await readJSON(join(root, "package.json")).catch(() => null);
+        addDeclarer(pkgJSON, root);
+      }),
+    );
     for (const [name, roots] of declarerRoots) {
       if (tracedPackages[name]) {
         continue;

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -98,17 +98,31 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
     const declarerRoots = new Map<string, Set<string>>(
       [...traceIncludeSet].map((name) => [name, new Set<string>()]),
     );
+    const addDeclarer = (pkgJSON: PackageJson | null | undefined, root: string) => {
+      if (!pkgJSON) {
+        return;
+      }
+      const deps = {
+        ...pkgJSON.dependencies,
+        ...pkgJSON.peerDependencies,
+        ...pkgJSON.optionalDependencies,
+      };
+      for (const depName of Object.keys(deps)) {
+        declarerRoots.get(depName)?.add(root);
+      }
+    };
     for (const tracedPackage of Object.values(tracedPackages)) {
       for (const versionEntry of Object.values(tracedPackage.versions)) {
-        const deps = {
-          ...versionEntry.pkgJSON.dependencies,
-          ...versionEntry.pkgJSON.peerDependencies,
-          ...versionEntry.pkgJSON.optionalDependencies,
-        };
-        for (const depName of Object.keys(deps)) {
-          declarerRoots.get(depName)?.add(versionEntry.path);
-        }
+        addDeclarer(versionEntry.pkgJSON, versionEntry.path);
       }
+    }
+    // Caller-provided roots of packages that are bundled (not traced) but still
+    // declare `traceInclude` names — e.g. a package the caller bundles that
+    // dynamically loads a native dependency. Without these, such names only
+    // resolve from `rootDir`, which fails under pnpm's non-hoisted layout.
+    for (const root of new Set(opts.traceIncludeRoots || [])) {
+      const pkgJSON = await readJSON(join(root, "package.json")).catch(() => null);
+      addDeclarer(pkgJSON, root);
     }
     for (const [name, roots] of declarerRoots) {
       if (tracedPackages[name]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,8 @@ export interface ExternalsTraceOptions {
    * location — and under pnpm it is not hoisted to `rootDir` either. Pass the
    * roots of such bundled packages here so their declared `traceInclude` names
    * resolve from the instance the dependent actually uses.
+   *
+   * Relative paths are resolved against {@link rootDir}.
    */
   traceIncludeRoots?: string[];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,20 @@ export interface ExternalsTraceOptions {
   traceInclude?: string[];
 
   /**
+   * Additional package roots to consider as declarers when resolving
+   * {@link traceInclude} names.
+   *
+   * `traceInclude` names are normally resolved from the roots of *traced*
+   * packages that declare them. A package that is bundled by the caller (rather
+   * than externalized) never becomes a traced package, so a native dependency it
+   * declares (e.g. `sharp` loaded dynamically) cannot be resolved from its real
+   * location — and under pnpm it is not hoisted to `rootDir` either. Pass the
+   * roots of such bundled packages here so their declared `traceInclude` names
+   * resolve from the instance the dependent actually uses.
+   */
+  traceIncludeRoots?: string[];
+
+  /**
    * List of package names to include all files for in the trace (not just nft-detected ones).
    *
    * Each item can be a package name string or a tuple of `[packageName, { glob }]` to customize the glob pattern.

--- a/test/fixture-pnpm/bundled-entry.mjs
+++ b/test/fixture-pnpm/bundled-entry.mjs
@@ -1,0 +1,6 @@
+// Simulates the app AND its declaring package (`@fixture/pnpm-app`) being
+// *bundled* rather than externalized: nothing here becomes a traced package, so
+// `pnpm-app` never contributes a declarer root. The nested native dep it depends
+// on can therefore only be resolved when its declarer root is supplied via
+// `traceIncludeRoots`. See test/pnpm.test.ts.
+export default "bundled";

--- a/test/pnpm.test.ts
+++ b/test/pnpm.test.ts
@@ -107,4 +107,47 @@ describe("pnpm .pnpm nested dependency tracing", () => {
 
     await expectTracedNativeVersion(`${outDir}/node_modules/@fixture/pnpm-native`);
   });
+
+  // The declarer of the native dep (`pnpm-app`) is *bundled*, not externalized,
+  // so it never becomes a traced package and cannot contribute a declarer root.
+  // nitro supplies the roots of bundled packages via `traceIncludeRoots`, which
+  // is the only way the nested native dep can be resolved from the version the
+  // dependent actually uses. https://github.com/unjs/nf3/issues/49
+  it("resolves traceInclude against a bundled declarer via traceIncludeRoots", async () => {
+    const outDir = `${fixtureDir}/.output-bundled`;
+    await rm(outDir, { recursive: true, force: true });
+
+    const appRoot = `${nodeModules}/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app`;
+    await traceNodeModules([`${fixtureDir}/bundled-entry.mjs`], {
+      rootDir: fixtureDir,
+      outDir,
+      traceInclude: ["@fixture/pnpm-native"],
+      traceIncludeRoots: [appRoot],
+    });
+
+    await expectTracedNativeVersion(`${outDir}/node_modules/@fixture/pnpm-native`);
+  });
+
+  // Guards the fix above: without `traceIncludeRoots`, a bundled declarer's
+  // nested native dep resolves only from `rootDir`, which under pnpm holds just
+  // the unrelated hoisted decoy (9.9.9, no native binary) — never the 1.0.0 the
+  // dependent actually uses.
+  it("without traceIncludeRoots, a bundled declarer's nested native dep is missed", async () => {
+    const outDir = `${fixtureDir}/.output-bundled-nofix`;
+    await rm(outDir, { recursive: true, force: true });
+
+    await traceNodeModules([`${fixtureDir}/bundled-entry.mjs`], {
+      rootDir: fixtureDir,
+      outDir,
+      traceInclude: ["@fixture/pnpm-native"],
+    });
+
+    const nativeDir = `${outDir}/node_modules/@fixture/pnpm-native`;
+    const traced = existsSync(`${nativeDir}/package.json`)
+      ? JSON.parse(await readFile(`${nativeDir}/package.json`, "utf8"))
+      : undefined;
+    // Only the decoy is reachable from rootDir, and it ships no native binary.
+    expect(traced?.version).not.toBe(NESTED_VERSION);
+    expect(existsSync(`${nativeDir}/native.node`)).toBe(false);
+  });
 });

--- a/test/pnpm.test.ts
+++ b/test/pnpm.test.ts
@@ -128,6 +128,24 @@ describe("pnpm .pnpm nested dependency tracing", () => {
     await expectTracedNativeVersion(`${outDir}/node_modules/@fixture/pnpm-native`);
   });
 
+  // A relative `traceIncludeRoots` entry must resolve against `rootDir`, not
+  // `process.cwd()` — otherwise the declarer's package.json read silently misses
+  // and the nested native dep falls back to the root decoy.
+  it("resolves a relative traceIncludeRoots entry against rootDir", async () => {
+    const outDir = `${fixtureDir}/.output-bundled-relative`;
+    await rm(outDir, { recursive: true, force: true });
+
+    const relAppRoot = "node_modules/.pnpm/@fixture+pnpm-app@1.0.0/node_modules/@fixture/pnpm-app";
+    await traceNodeModules([`${fixtureDir}/bundled-entry.mjs`], {
+      rootDir: fixtureDir,
+      outDir,
+      traceInclude: ["@fixture/pnpm-native"],
+      traceIncludeRoots: [relAppRoot],
+    });
+
+    await expectTracedNativeVersion(`${outDir}/node_modules/@fixture/pnpm-native`);
+  });
+
   // Guards the fix above: without `traceIncludeRoots`, a bundled declarer's
   // nested native dep resolves only from `rootDir`, which under pnpm holds just
   // the unrelated hoisted decoy (9.9.9, no native binary) — never the 1.0.0 the


### PR DESCRIPTION
## Problem

`traceInclude` names are resolved from `rootDir` plus the roots of *traced* (externalized) packages that declare them as a dependency. This misses a real case:

A package the caller **bundles** (rather than externalizes) never becomes a traced package, so a native, dynamically-loaded dependency it declares (e.g. `sharp` / `bcrypt`) has **no declarer root**. Its name then only resolves from `rootDir` — and under **pnpm** the nested dep is not hoisted to `rootDir`, so it is silently dropped from the trace.

This is the residual failure behind unjs/nf3#49 / nitrojs/nitro#4391: `sharp`/`bcrypt` declared by a *bundled* package (e.g. `nitropage`) were never traced.

## Change

Add a `traceIncludeRoots?: string[]` option to `traceNodeModules`. These caller-provided package roots (e.g. the roots of bundled packages) are also considered as declarers when building the resolve-from map for `traceInclude` names, so each name resolves from the instance the dependent actually uses (correct version, pnpm's nested `.pnpm` location).

The consumer (nitro) collects the roots of bundled packages from its module graph and passes them here — see the companion nitro PR.

## Tests

`test/pnpm.test.ts` (fixture `test/fixture-pnpm/bundled-entry.mjs`):
- **bundled declarer via `traceIncludeRoots`** — the native dep's declarer is bundled (not in the input), and is only traceable via `traceIncludeRoots`. Verified red before the fix (traces the root decoy `9.9.9` instead of the nested `1.0.0`) and green after.
- **negative guard** — without `traceIncludeRoots`, the nested native dep is missed (only the hoisted decoy, no native binary, is reachable).

Full suite: 39 passed, `tsgo` clean.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracing dependencies from additional package roots, improving resolution when an app’s declaring package is bundled.
  * Relative package-root paths are now resolved consistently against the project root.

* **Bug Fixes**
  * Improved dependency tracing for nested pnpm setups so native dependencies are more reliably included.
  * Fixed cases where traced dependencies could be missed when the declaring package was not directly externalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->