### PR TITLE
fix(trace): resolve `traceInclude` packages under minimal conditions (#57)

### DIFF
--- a/src/trace.ts
+++ b/src/trace.ts
@@ -132,6 +132,15 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
         addDeclarer(pkgJSON, root);
       }),
     );
+    // Resolve `traceInclude` names with a permissive superset of the caller's
+    // conditions. `traceInclude` only needs to *locate* a package to copy it, so
+    // widening conditions never changes runtime behaviour — but resolving with
+    // the raw caller conditions (e.g. Nitro's `["node"]`) silently drops packages
+    // whose `exports` are keyed only by `import`/`require`, with no top-level
+    // `default` or `./package.json` export. https://github.com/unjs/nf3/issues/57
+    const includeConditions = [
+      ...new Set([...(opts.conditions || DEFAULT_CONDITIONS), "import", "require", "default"]),
+    ];
     for (const [name, roots] of declarerRoots) {
       if (tracedPackages[name]) {
         continue;
@@ -146,7 +155,7 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
         // `<name>/package.json` directly is unreliable since a package's
         // `exports` map usually does not expose it.
         resolved =
-          resolveModulePath(name, { try: true, from, conditions: opts.conditions }) ||
+          resolveModulePath(name, { try: true, from, conditions: includeConditions }) ||
           resolveModulePath(name + "/package.json", { try: true, from });
         if (resolved) {
           break;

--- a/test/fixture/force-include-conditions.mjs
+++ b/test/fixture/force-include-conditions.mjs
@@ -1,0 +1,3 @@
+// The app never statically imports `@fixture/conditional-exports`; it is
+// force-traced via `traceInclude` under minimal caller `conditions`.
+export default "app";

--- a/test/fixture/node_modules/@fixture/conditional-dep/index.mjs
+++ b/test/fixture/node_modules/@fixture/conditional-dep/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/conditional-dep@1.0.0";

--- a/test/fixture/node_modules/@fixture/conditional-dep/package.json
+++ b/test/fixture/node_modules/@fixture/conditional-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/conditional-dep",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/node_modules/@fixture/conditional-exports/index.cjs
+++ b/test/fixture/node_modules/@fixture/conditional-exports/index.cjs
@@ -1,0 +1,1 @@
+module.exports = "@fixture/conditional-exports@1.0.0 (cjs)";

--- a/test/fixture/node_modules/@fixture/conditional-exports/index.mjs
+++ b/test/fixture/node_modules/@fixture/conditional-exports/index.mjs
@@ -1,0 +1,7 @@
+// Force-traced via `traceInclude`. Its `exports` map is keyed only by
+// `import`/`require` — with no top-level `default` or `./package.json` export —
+// so resolving it under minimal caller conditions (e.g. `["node"]`) must still
+// locate the package. https://github.com/unjs/nf3/issues/57
+import dep from "@fixture/conditional-dep";
+
+export default `@fixture/conditional-exports@1.0.0+${dep}`;

--- a/test/fixture/node_modules/@fixture/conditional-exports/package.json
+++ b/test/fixture/node_modules/@fixture/conditional-exports/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fixture/conditional-exports",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs"
+    }
+  },
+  "dependencies": {
+    "@fixture/conditional-dep": "1.0.0"
+  }
+}

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -142,6 +142,35 @@ describe("traceNodeModules", () => {
     await expect(stat(path.join(scope, "dev-dep"))).rejects.toThrow();
   });
 
+  // Regression for https://github.com/unjs/nf3/issues/57
+  // A package force-included via `traceInclude` whose `exports` map is keyed only
+  // by `import`/`require` (no top-level `default` or `./package.json` export) must
+  // still resolve when the caller passes minimal `conditions` (e.g. Nitro's
+  // `["node"]`). Previously it was silently dropped because resolution used the
+  // raw caller conditions, which match none of the package's export keys.
+  it("traces a traceInclude package with import/require-only exports under minimal conditions", async () => {
+    const rootDir = fileURLToPath(new URL("fixture", import.meta.url));
+    const input = fileURLToPath(new URL("fixture/force-include-conditions.mjs", import.meta.url));
+    const outDir = fileURLToPath(new URL("dist/force-include-conditions", import.meta.url));
+
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+    await cp(input, `${outDir}/force-include-conditions.mjs`);
+
+    await traceNodeModules([input], {
+      rootDir,
+      outDir,
+      conditions: ["node"],
+      traceInclude: ["@fixture/conditional-exports"],
+    });
+
+    const scope = path.join(outDir, "node_modules", "@fixture");
+    // The force-included package (import/require-only exports) is copied...
+    await expect(stat(path.join(scope, "conditional-exports", "index.mjs"))).resolves.toBeTruthy();
+    // ...along with its transitively-traced runtime dependency.
+    await expect(stat(path.join(scope, "conditional-dep", "index.mjs"))).resolves.toBeTruthy();
+  });
+
   // Regression for https://github.com/unjs/nf3/issues/47
   // `@fixture/native-libvips` mirrors `@img/sharp-libvips-*`: it is declared only
   // as an `optionalDependency` (loaded at runtime via native `@rpath` links, with


### PR DESCRIPTION
## Summary

Fixes #57.

`traceInclude` package resolution used the caller's raw `conditions` (e.g. Nitro's `["node"]`). Packages whose `exports` map is keyed only by `import`/`require` — with no top-level `default` or `./package.json` export (e.g. `sharp`) — match none of those keys, so `resolveModulePath` returns `undefined` and the `<name>/package.json` fallback also fails (such packages rarely expose `package.json` via `exports`). The package was then silently dropped from the trace.

The fix resolves `traceInclude` names with a permissive superset of the caller's conditions (`import`/`require`/`default` added). Since `traceInclude` only needs to *locate* a package in order to copy it wholesale, widening conditions here never changes downstream runtime behaviour.

```ts
const includeConditions = [
  ...new Set([...(opts.conditions || DEFAULT_CONDITIONS), "import", "require", "default"]),
];
```

## Test plan

Added a regression test (`test/trace.test.ts`) with a new fixture `@fixture/conditional-exports` whose `exports` are keyed only by `import`/`require`. It is force-included with `conditions: ["node"]`, and the test asserts both the package and its transitively-traced runtime dependency are copied. The test fails on `main` (package dropped) and passes with the fix.

Full suite: 41/41 passing; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package tracing so force-included packages are resolved more reliably, even when their export conditions are limited.
  * Fixed an issue where some traced dependencies could be missed when using minimal resolution conditions.
* **Tests**
  * Added regression coverage for force-included packages and their dependent runtime files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->