### PR TITLE
fix(trace): resolve `traceInclude` subpath entries and warn on unresolvable ones

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -19,6 +19,15 @@ export function parseNodeModulePath(path: string): {
 
 const IMPORT_RE = /^(?!\.)(?<name>[^@/\\]+|@[^/\\]+[/\\][^/\\]+)(?:[/\\](?<subpath>.+))?$/;
 
+/**
+ * Package name of a bare import specifier, dropping any subpath — the same
+ * name/subpath split `parseNodeModulePath` applies to absolute paths, including
+ * scoped `@scope/pkg/sub`. Returns `undefined` for relative/absolute ids.
+ */
+export function importPkgName(id: string): string | undefined {
+  return IMPORT_RE.exec(id)?.groups?.name;
+}
+
 export function toImport(id: string): string | undefined {
   if (isAbsolute(id)) {
     const { name, subpath } = parseNodeModulePath(id) || {};

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, normalize, relative, resolve } from "pathe";
 import semver from "semver";
 import { resolveModulePath } from "exsolve";
 import {
+  importPkgName,
   isWindows,
   parseNodeModulePath,
   readJSON,
@@ -92,7 +93,16 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
   // Driving this off declared dependencies (instead of trying every name against
   // every root) keeps it cheap even when a large allowlist is passed.
   // https://github.com/unjs/nf3/issues/49
-  const traceIncludeSet = new Set((opts.traceInclude || []).filter((n) => !isAbsolute(n)));
+  // Normalize non-absolute entries to their bare package name: entries are
+  // matched against declared dependency *names*, so a subpath entry like
+  // `sharp/wasm` (the exact import specifier that failed to resolve — a natural
+  // thing to pass) would otherwise never match a declarer and be silently
+  // dropped under pnpm's non-hoisted layout. Whole-package copy is the
+  // established semantics, so collapsing the subpath matches intent.
+  // https://github.com/unjs/nf3/issues/60
+  const traceIncludeSet = new Set(
+    (opts.traceInclude || []).filter((n) => !isAbsolute(n)).map((n) => importPkgName(n) || n),
+  );
   if (traceIncludeSet.size > 0) {
     // Collect the roots of traced packages that declare each requested name.
     const declarerRoots = new Map<string, Set<string>>(
@@ -149,26 +159,39 @@ export async function traceNodeModules(input: string[], opts: ExternalsTraceOpti
       // dependent actually uses (correct version, and pnpm's non-hoisted nested
       // location). `rootDir` is only a fallback — otherwise an unrelated copy
       // hoisted at the root could shadow the dependent's real dependency.
-      let resolved: string | undefined;
+      let depPath: string | undefined;
       for (const from of [...roots, rootDir]) {
         // Resolve the bare name (then derive the package root below). Resolving
         // `<name>/package.json` directly is unreliable since a package's
         // `exports` map usually does not expose it.
-        resolved =
+        const resolved =
           resolveModulePath(name, { try: true, from, conditions: includeConditions }) ||
           resolveModulePath(name + "/package.json", { try: true, from });
         if (resolved) {
+          const { dir, name: resolvedName } = parseNodeModulePath(resolved);
+          if (dir && resolvedName) {
+            depPath = join(dir, resolvedName);
+            break;
+          }
+        }
+        // Fall back to locating the package directory on disk. Covers packages
+        // whose `exports` map omits both `.` and `./package.json` (e.g. the
+        // `native-libvips` shape), which the resolver above cannot find — the
+        // same disk-walk fallback used for optionalDependencies below.
+        depPath = await resolvePackageDir(name, from);
+        if (depPath) {
           break;
         }
       }
-      if (!resolved) {
+      if (!depPath) {
+        // An explicit `traceInclude` entry that resolves from no root is a
+        // "this must be in the output" instruction gone unhonored — warn rather
+        // than turn a build-time problem into a silent production runtime crash.
+        console.warn(
+          `nf3: could not resolve \`traceInclude\` entry ${JSON.stringify(name)} from any root`,
+        );
         continue;
       }
-      const { dir, name: resolvedName } = parseNodeModulePath(resolved);
-      if (!dir || !resolvedName) {
-        continue;
-      }
-      const depPath = join(dir, resolvedName);
       const depPkgJSON = await readJSON(join(depPath, "package.json")).catch(() => null);
       if (!depPkgJSON) {
         continue;

--- a/test/fixture/node_modules/@fixture/subpath-framework/index.mjs
+++ b/test/fixture/node_modules/@fixture/subpath-framework/index.mjs
@@ -1,0 +1,4 @@
+// A "framework" package the caller bundles (not traced) but which declares
+// `@fixture/subpath-native` as a dependency and loads it dynamically. Its root
+// is passed via `traceIncludeRoots` so the native dep resolves from here.
+export default "@fixture/subpath-framework";

--- a/test/fixture/node_modules/@fixture/subpath-framework/node_modules/@fixture/subpath-native/index.mjs
+++ b/test/fixture/node_modules/@fixture/subpath-framework/node_modules/@fixture/subpath-native/index.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/subpath-native";

--- a/test/fixture/node_modules/@fixture/subpath-framework/node_modules/@fixture/subpath-native/package.json
+++ b/test/fixture/node_modules/@fixture/subpath-framework/node_modules/@fixture/subpath-native/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/subpath-native",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "./sub": "./sub.mjs"
+  }
+}

--- a/test/fixture/node_modules/@fixture/subpath-framework/node_modules/@fixture/subpath-native/sub.mjs
+++ b/test/fixture/node_modules/@fixture/subpath-framework/node_modules/@fixture/subpath-native/sub.mjs
@@ -1,0 +1,1 @@
+export default "@fixture/subpath-native/sub";

--- a/test/fixture/node_modules/@fixture/subpath-framework/package.json
+++ b/test/fixture/node_modules/@fixture/subpath-framework/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/subpath-framework",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "@fixture/subpath-native": "1.0.0"
+  }
+}

--- a/test/fixture/subpath.mjs
+++ b/test/fixture/subpath.mjs
@@ -1,0 +1,4 @@
+// Regression fixture for https://github.com/unjs/nf3/issues/60
+// The app never statically imports the native package; it enters the output
+// solely through a *subpath* `traceInclude` entry (`@fixture/subpath-native/sub`).
+export default "app";

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -171,6 +171,39 @@ describe("traceNodeModules", () => {
     await expect(stat(path.join(scope, "conditional-dep", "index.mjs"))).resolves.toBeTruthy();
   });
 
+  // Regression for https://github.com/unjs/nf3/issues/60
+  // A `traceInclude` entry carrying a subpath (e.g. `@fixture/subpath-native/sub`
+  // — the exact specifier that failed to resolve) must trace the whole package.
+  // Here `@fixture/subpath-native` is declared only by `@fixture/subpath-framework`
+  // (bundled, passed via `traceIncludeRoots`) and nested under it rather than
+  // hoisted to the app root — mirroring pnpm's non-hoisted layout. Previously the
+  // subpath entry was compared against bare dependency names, never matched the
+  // declarer, and — unresolvable from `rootDir` — was silently dropped, leaving the
+  // package out of the output. It must now normalize to its package name and match.
+  // The package also ships a restrictive `exports` map (only `./sub`, no `.` nor
+  // `./package.json`) like real native deps, so it is located via the disk walk.
+  it("traces a traceInclude entry that carries a subpath", async () => {
+    const rootDir = fileURLToPath(new URL("fixture", import.meta.url));
+    const input = fileURLToPath(new URL("fixture/subpath.mjs", import.meta.url));
+    const outDir = fileURLToPath(new URL("dist/subpath", import.meta.url));
+
+    await rm(outDir, { recursive: true, force: true });
+    await mkdir(outDir, { recursive: true });
+    await cp(input, `${outDir}/subpath.mjs`);
+
+    await traceNodeModules([input], {
+      rootDir,
+      outDir,
+      traceIncludeRoots: ["node_modules/@fixture/subpath-framework"],
+      traceInclude: ["@fixture/subpath-native/sub"],
+    });
+
+    // The whole package is copied even though only its subpath was requested.
+    const nativeDir = path.join(outDir, "node_modules", "@fixture", "subpath-native");
+    await expect(stat(path.join(nativeDir, "index.mjs"))).resolves.toBeTruthy();
+    await expect(stat(path.join(nativeDir, "sub.mjs"))).resolves.toBeTruthy();
+  });
+
   // Regression for https://github.com/unjs/nf3/issues/47
   // `@fixture/native-libvips` mirrors `@img/sharp-libvips-*`: it is declared only
   // as an `optionalDependency` (loaded at runtime via native `@rpath` links, with


### PR DESCRIPTION
Fixes #60.

## Problem

Two gaps in the `traceInclude` public API of `traceNodeModules`, both surfaced while fixing nitrojs/nitro#4420:

1. **Subpath entries never match declarers.** `traceInclude` entries are compared against *bare* declared dependency names, so an entry like `sharp/wasm` — the exact import specifier that failed to resolve, a natural thing to pass — silently does nothing under pnpm's non-hoisted layout: the `pkg/sub` key never matches a declared dependency name, and (being unresolvable from `rootDir`) the package is dropped from the output, causing a runtime crash.
2. **Unresolvable entries are silently dropped.** A `traceInclude` entry that resolves from no root is an explicit "this must be in the output" instruction that went unhonored with zero signal, turning a build-time problem into a production runtime crash.

## Fix

- **Normalize** non-absolute `traceInclude` entries to their bare package name at ingestion (new `importPkgName` helper, reusing the existing `IMPORT_RE` split — scoped-aware, e.g. `@scope/pkg/sub` → `@scope/pkg`). Whole-package copy is the established `traceInclude` semantics, so collapsing the subpath matches intent.
- **On-disk fallback:** the resolution loop now falls back to `resolvePackageDir` (node_modules walk) when the module resolver can't locate the package — covers native packages whose `exports` map omits both `.` and `./package.json` (`sharp/wasm`-style). This mirrors the fallback already used by the optionalDependencies pass, and keeps the new warning from firing for packages that are in fact locatable.
- **Warn** (`nf3: could not resolve \`traceInclude\` entry "X" from any root`) instead of silently dropping an entry that resolves from no root.

## Test

Adds a regression test (`traces a traceInclude entry that carries a subpath`) with a synthetic pnpm non-hoisted fixture: `@fixture/subpath-native` (restrictive `exports`, only `./sub`) is declared solely by `@fixture/subpath-framework` (bundled, passed via `traceIncludeRoots`) and nested under it rather than hoisted. Passing `traceInclude: ["@fixture/subpath-native/sub"]` must trace the whole package. The test fails on `main` (package missing from output) and passes with this change. Full suite: 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tracing for package subpaths, ensuring the complete package is included rather than only the requested subpath.
  * Improved dependency resolution across different package layouts.
  * Added warnings when requested packages cannot be resolved.

* **Tests**
  * Added regression coverage verifying traced packages include all required files, including package entry points and submodules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->